### PR TITLE
Emulate mac keyboard input accurately on mpx68k

### DIFF
--- a/X68000 macOS/GameViewController.swift
+++ b/X68000 macOS/GameViewController.swift
@@ -21,6 +21,26 @@ class MouseCaptureSKView: SKView {
         return true
     }
     
+    // Ensure macOS text input system delivers composed text (IME, layout-correct chars)
+    override func keyDown(with event: NSEvent) {
+        // First, let the text input system translate the event into text
+        self.interpretKeyEvents([event])
+        // Then, keep default behavior so the scene still gets keyDown for non-text/special keys
+        super.keyDown(with: event)
+    }
+    
+    override func insertText(_ insertString: Any) {
+        let text: String
+        if let s = insertString as? String {
+            text = s
+        } else if let a = insertString as? NSAttributedString {
+            text = a.string
+        } else {
+            return
+        }
+        gameViewController?.gameScene?.handleTextInput(text)
+    }
+    
     override func mouseDown(with event: NSEvent) {
         infoLog("🖱️ MouseCaptureSKView.mouseDown - forwarding to GameViewController", category: .input)
         gameViewController?.mouseDown(with: event)


### PR DESCRIPTION
Add macOS text input support to accurately emit characters, fixing issues with insufficient key mapping.

The previous scancode-based key mapping was insufficient for various macOS keyboard layouts and IME, leading to incorrect character input. This change ensures that actual text typed by the user is correctly translated and sent to the emulator, improving the user experience for character entry.

---
<a href="https://cursor.com/background-agent?bcId=bc-13113ed8-dea4-46cb-8b77-1aed92fe58eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13113ed8-dea4-46cb-8b77-1aed92fe58eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

