### PR TITLE
Codex/scsi u claude fixes

### DIFF
--- a/X68000 Shared/FileSystem.swift
+++ b/X68000 Shared/FileSystem.swift
@@ -2357,7 +2357,7 @@ class FileSystem {
 
     // MARK: - ROM Loading
 
-    func loadIPLROM() -> Result<Void, ROMLoadError>
+    func loadIPLROM(selectedStorageBusMode: Int) -> Result<Void, ROMLoadError>
     {
         infoLog("==== Load IPLROM ====", category: .fileSystem)
 
@@ -2410,8 +2410,7 @@ class FileSystem {
         // SCSIEXROM.DAT (external SCSI, SCSIEX type) is required — its layout
         // matches the IPL ROM IOCS table.  SCSIINROM.DAT is an internal SCSI
         // ROM (SCSIIN type) with an incompatible layout and cannot be used.
-        let storageBusMode = UserDefaults.standard.integer(forKey: "StorageBusMode")
-        if storageBusMode == 1 || storageBusMode == 2 {
+        if selectedStorageBusMode == 1 || selectedStorageBusMode == 2 {
             guard let scsiRomURL = findFileInDocuments("SCSIEXROM.DAT") else {
                 errorLog("CRITICAL: SCSIEXROM.DAT not found while SCSI/SCSI-U mode is enabled", category: .fileSystem)
                 return .failure(.missingFile("SCSIEXROM.DAT"))

--- a/X68000 Shared/FileSystem.swift
+++ b/X68000 Shared/FileSystem.swift
@@ -649,11 +649,17 @@ class FileSystem {
         // would clobber the freshly-loaded buffer and break boot.
         let userMountedFDD0 = X68000_IsFDDReady(0) != 0
         let userMountedFDD1 = X68000_IsFDDReady(1) != 0
-        let scsiMounted = (X68000_GetStorageBusMode() == 1 && X68000_SCSI_IsMounted(0, 0) != 0)
-        let sasiMounted = (X68000_GetStorageBusMode() == 0 && X68000_IsHDDReady() != 0)
+        let busMode = X68000_GetStorageBusMode()
+        let scsiMounted = (busMode == 1 && X68000_SCSI_IsMounted(0, 0) != 0)
+        let sasiMounted = (busMode == 0 && X68000_IsHDDReady() != 0)
+        #if os(macOS)
+        let scsiUMounted = (busMode == 2 && X68000_SCSIU_IsConnected() != 0)
+        #else
+        let scsiUMounted = false
+        #endif
 
-        if restored && (scsiMounted || sasiMounted) && !(userMountedFDD0 || userMountedFDD1) {
-            infoLog("FileSystem: HDD ready after async restore (scsi=\(scsiMounted) sasi=\(sasiMounted)), issuing post-restore reset", category: .fileSystem)
+        if restored && (scsiMounted || sasiMounted || scsiUMounted) && !(userMountedFDD0 || userMountedFDD1) {
+            infoLog("FileSystem: HDD ready after async restore (scsi=\(scsiMounted) sasi=\(sasiMounted) scsiU=\(scsiUMounted)), issuing post-restore reset", category: .fileSystem)
             X68000_Reset()
         } else if restored {
             infoLog("FileSystem: skipping post-restore reset (user already mounted media)", category: .fileSystem)
@@ -2400,13 +2406,14 @@ class FileSystem {
             }
         }
 
-        // Optional: Load SCSI external ROM (8KB) for SCSI mode.
+        // Optional: Load SCSI external ROM (8KB) for SCSI / SCSI-U mode.
         // SCSIEXROM.DAT (external SCSI, SCSIEX type) is required — its layout
         // matches the IPL ROM IOCS table.  SCSIINROM.DAT is an internal SCSI
         // ROM (SCSIIN type) with an incompatible layout and cannot be used.
-        if UserDefaults.standard.integer(forKey: "StorageBusMode") == 1 {
+        let storageBusMode = UserDefaults.standard.integer(forKey: "StorageBusMode")
+        if storageBusMode == 1 || storageBusMode == 2 {
             guard let scsiRomURL = findFileInDocuments("SCSIEXROM.DAT") else {
-                errorLog("CRITICAL: SCSIEXROM.DAT not found while SCSI mode is enabled", category: .fileSystem)
+                errorLog("CRITICAL: SCSIEXROM.DAT not found while SCSI/SCSI-U mode is enabled", category: .fileSystem)
                 return .failure(.missingFile("SCSIEXROM.DAT"))
             }
             do {

--- a/X68000 Shared/GameScene.swift
+++ b/X68000 Shared/GameScene.swift
@@ -936,18 +936,34 @@ class GameScene: SKScene {
         // Initialize emulator AFTER ROM files are loaded
         X68000_Init(samplingRate)
 
+        #if os(macOS)
+        let persistedStorageBusMode = UserDefaults.standard.integer(forKey: "StorageBusMode")
+        switch persistedStorageBusMode {
+        case 1, 2:
+            X68000_SetStorageBusMode(Int32(persistedStorageBusMode))
+        default:
+            X68000_SetStorageBusMode(0)
+        }
+        #endif
+
         fileSystem.loadSRAM()
 
         // Use new state restore system for auto-mounting
         debugLog("GameScene: Calling bootWithStateRestore()", category: .fileSystem)
         fileSystem.bootWithStateRestore()
-        var scsiMounted = (X68000_GetStorageBusMode() == 1 && X68000_SCSI_IsMounted(0, 0) != 0)
+        let storageBusMode = X68000_GetStorageBusMode()
+        var scsiMounted = (storageBusMode == 1 && X68000_SCSI_IsMounted(0, 0) != 0)
         if !scsiMounted {
             scsiMounted = restoreScsiFromDefaultsIfNeeded()
         }
         let sasiMounted = (X68000_GetStorageBusMode() == 0 && X68000_IsHDDReady() != 0)
-        if scsiMounted || sasiMounted {
-            infoLog("GameScene: HDD ready after restore (scsi=\(scsiMounted) sasi=\(sasiMounted)), issuing post-restore reset", category: .fileSystem)
+        #if os(macOS)
+        let scsiUMounted = (X68000_GetStorageBusMode() == 2 && X68000_SCSIU_IsConnected() != 0)
+        #else
+        let scsiUMounted = false
+        #endif
+        if scsiMounted || sasiMounted || scsiUMounted {
+            infoLog("GameScene: HDD ready after restore (scsi=\(scsiMounted) sasi=\(sasiMounted) scsiU=\(scsiUMounted)), issuing post-restore reset", category: .fileSystem)
             X68000_Reset()
         }
         if let warmupRaw = ProcessInfo.processInfo.environment["X68_BOOT_WARMUP_STEPS"],

--- a/X68000 Shared/GameScene.swift
+++ b/X68000 Shared/GameScene.swift
@@ -919,8 +919,14 @@ class GameScene: SKScene {
     }
 
     private func startEmulator(with fileSystem: FileSystem) {
+        #if os(macOS)
+        let selectedStorageBusMode = UserDefaults.standard.integer(forKey: "StorageBusMode")
+        #else
+        let selectedStorageBusMode = 0
+        #endif
+
         // Load ROM files FIRST, before any emulator initialization
-        switch fileSystem.loadIPLROM() {
+        switch fileSystem.loadIPLROM(selectedStorageBusMode: selectedStorageBusMode) {
         case .failure(let romError):
             errorLog("CRITICAL: IPLROM load failed: \(romError)", category: .emulation)
             notifyROMLoadError(romError)
@@ -937,10 +943,9 @@ class GameScene: SKScene {
         X68000_Init(samplingRate)
 
         #if os(macOS)
-        let persistedStorageBusMode = UserDefaults.standard.integer(forKey: "StorageBusMode")
-        switch persistedStorageBusMode {
+        switch selectedStorageBusMode {
         case 1, 2:
-            X68000_SetStorageBusMode(Int32(persistedStorageBusMode))
+            X68000_SetStorageBusMode(Int32(selectedStorageBusMode))
         default:
             X68000_SetStorageBusMode(0)
         }

--- a/X68000 Shared/px68k/fmgen/X68000 macOS-Bridging-Header.h
+++ b/X68000 Shared/px68k/fmgen/X68000 macOS-Bridging-Header.h
@@ -50,6 +50,10 @@ int X68000_SCSI_IsMounted(int host, int id);
 const char* X68000_SCSI_GetImagePath(int host, int id);
 int X68000_SCSI_Mount(int host, int id, const char* path, int flags);
 int X68000_SCSI_Eject(int host, int id);
+int X68000_SCSIU_Connect(void);
+void X68000_SCSIU_Disconnect(void);
+int X68000_SCSIU_IsConnected(void);
+const char* X68000_SCSIU_GetStatus(void);
 void Memory_SetSCSIMode(void);
 void Memory_ClearSCSIMode(void);
 

--- a/X68000 Shared/px68k/x11/winx68k.cpp
+++ b/X68000 Shared/px68k/x11/winx68k.cpp
@@ -591,7 +591,8 @@ WinX68k_Reset(void)
 #if defined(HAVE_C68K)
 	// IPL-ROM-first SCSI boot: IPL ROMに通常起動させ、SASIデバイススキャン時に
 	// SCSIブートセクタを注入する。
-	if (g_storage_bus_mode == 1 && g_scsi0_mounted) {
+	if ((g_storage_bus_mode == 1 && g_scsi0_mounted) ||
+	    (g_storage_bus_mode == 2 && SCSIU_IsConnected())) {
 		// Save SASI SRAM if switching from SASI mode
 		{
 			extern void WinX68k_SaveSASI_SRAM(void);
@@ -1454,10 +1455,11 @@ void X68000_SetStorageBusMode(int mode)
 		Memory_ClearSCSIMode();
 		WinX68k_RestoreSASI_SRAM();
 	} else if (g_storage_bus_mode == 2) {
-		// SCSI-U connection state is tracked separately. Until the physical
-		// transfer backend is wired into the IOCS/boot path, keep the memory
-		// map on the neutral SASI side to avoid stale synthetic SCSI state.
-		Memory_ClearSCSIMode();
+		if (SCSIU_IsConnected()) {
+			Memory_SetSCSIMode();
+		} else {
+			Memory_ClearSCSIMode();
+		}
 		WinX68k_RestoreSASI_SRAM();
 	}
 	// Note: SRAM boot device ($ED0018) is set by WinX68k_Reset for SCSI mode.
@@ -1538,7 +1540,7 @@ int X68000_SCSIU_Connect(void)
 
 	g_storage_bus_mode = 2;
 	SCSI_InvalidateTransferCache();
-	Memory_ClearSCSIMode();
+	Memory_SetSCSIMode();
 	WinX68k_RestoreSASI_SRAM();
 	X68000_AppendSCSILog("SCSI-U CONNECTED");
 	return 1;
@@ -1550,7 +1552,6 @@ void X68000_SCSIU_Disconnect(void)
 		SCSIU_StopBridge();
 	}
 	if (g_storage_bus_mode == 2) {
-		g_storage_bus_mode = 0;
 		Memory_ClearSCSIMode();
 		WinX68k_RestoreSASI_SRAM();
 	}

--- a/X68000 Shared/px68k/x11/winx68k.cpp
+++ b/X68000 Shared/px68k/x11/winx68k.cpp
@@ -97,7 +97,7 @@ DWORD skippedframes = 0;
 static int ClkUsed = 0;
 static int FrameSkipCount = 0;
 static int FrameSkipQueue = 0;
-static int g_storage_bus_mode = 0; // 0 = SASI, 1 = SCSI
+static int g_storage_bus_mode = 0; // 0 = SASI, 1 = SCSI image, 2 = SCSI-U
 static unsigned char SASI_IPLROM[0x20000] = {0};
 static int SASI_IPLROM_loaded = 0;
 static int s_scsi_ipl_needs_restore = 0;  // set when SASI IPLROM0 overrides IPL
@@ -154,6 +154,13 @@ static int g_scsi_force_redraw_attempts = 0;
 static void X68000_AppendSCSILog(const char* message);
 static DWORD X68000_ReadIplLong(DWORD offset, int useDirect);
 static DWORD X68000_DecodeIplVectorAddress(DWORD raw);
+
+static void
+WinX68k_ClearSCSIImageState(void)
+{
+	g_scsi0_mounted = 0;
+	g_scsi0_path[0] = '\0';
+}
 
 static DWORD
 X68000_NormalizeDecodedIplIocsHandler(DWORD decoded, DWORD sourceRaw, int* outCanonicalized)
@@ -1425,15 +1432,31 @@ int X68000_IsSCSIBootPending(void)
 
 void X68000_SetStorageBusMode(int mode)
 {
-	if (g_storage_bus_mode == 0 && mode == 1) {
+	if (g_storage_bus_mode == 0 && (mode == 1 || mode == 2)) {
 		WinX68k_SaveSASI_SRAM();
 	}
+	if (g_storage_bus_mode == 2 && mode != 2) {
+		SCSIU_StopBridge();
+	}
 
-	g_storage_bus_mode = (mode == 1) ? 1 : 0;
+	if (mode == 1) {
+		g_storage_bus_mode = 1;
+	} else if (mode == 2) {
+		g_storage_bus_mode = 2;
+	} else {
+		g_storage_bus_mode = 0;
+	}
+
 	if (g_storage_bus_mode == 0) {
 		// Restore the native SASI register map immediately so a prior SCSI
 		// session does not leave $E96000 routed to the SPC emulation.
 		// Also restore the pre-SCSI SRAM view before any Swift-side saveSRAM().
+		Memory_ClearSCSIMode();
+		WinX68k_RestoreSASI_SRAM();
+	} else if (g_storage_bus_mode == 2) {
+		// SCSI-U connection state is tracked separately. Until the physical
+		// transfer backend is wired into the IOCS/boot path, keep the memory
+		// map on the neutral SASI side to avoid stale synthetic SCSI state.
 		Memory_ClearSCSIMode();
 		WinX68k_RestoreSASI_SRAM();
 	}
@@ -1463,6 +1486,9 @@ int X68000_SCSI_Mount(int host, int id, const char* path, int flags)
 	if (host != 0 || id != 0 || path == NULL || path[0] == '\0') {
 		return 0;
 	}
+	if (SCSIU_IsConnected()) {
+		SCSIU_StopBridge();
+	}
 
 	if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] <= 0) {
 		printf("X68000_SCSI_Mount: HDD buffer not initialized for %s\n", path);
@@ -1490,11 +1516,55 @@ int X68000_SCSI_Eject(int host, int id)
 		return 0;
 	}
 
-	g_scsi0_mounted = 0;
-	g_scsi0_path[0] = '\0';
+	WinX68k_ClearSCSIImageState();
 	SCSI_InvalidateTransferCache();
 	X68000_EjectHDD();
 	return 1;
+}
+
+int X68000_SCSIU_Connect(void)
+{
+	if (!SCSIU_InitBridge()) {
+		return 0;
+	}
+	if (g_storage_bus_mode == 0) {
+		WinX68k_SaveSASI_SRAM();
+	}
+
+	if (g_scsi0_mounted) {
+		WinX68k_ClearSCSIImageState();
+		X68000_EjectHDD();
+	}
+
+	g_storage_bus_mode = 2;
+	SCSI_InvalidateTransferCache();
+	Memory_ClearSCSIMode();
+	WinX68k_RestoreSASI_SRAM();
+	X68000_AppendSCSILog("SCSI-U CONNECTED");
+	return 1;
+}
+
+void X68000_SCSIU_Disconnect(void)
+{
+	if (SCSIU_IsConnected()) {
+		SCSIU_StopBridge();
+	}
+	if (g_storage_bus_mode == 2) {
+		g_storage_bus_mode = 0;
+		Memory_ClearSCSIMode();
+		WinX68k_RestoreSASI_SRAM();
+	}
+	X68000_AppendSCSILog("SCSI-U DISCONNECTED");
+}
+
+int X68000_SCSIU_IsConnected(void)
+{
+	return SCSIU_IsConnected();
+}
+
+const char* X68000_SCSIU_GetStatus(void)
+{
+	return SCSIU_GetStatus();
 }
 
 unsigned char* X68000_GetSRAMPointer()

--- a/X68000 Shared/px68k/x11/winx68k.cpp
+++ b/X68000 Shared/px68k/x11/winx68k.cpp
@@ -1552,6 +1552,7 @@ void X68000_SCSIU_Disconnect(void)
 		SCSIU_StopBridge();
 	}
 	if (g_storage_bus_mode == 2) {
+		g_storage_bus_mode = 0;
 		Memory_ClearSCSIMode();
 		WinX68k_RestoreSASI_SRAM();
 	}

--- a/X68000 Shared/px68k/x11/winx68k.h
+++ b/X68000 Shared/px68k/x11/winx68k.h
@@ -44,6 +44,10 @@ extern int realdisp_w, realdisp_h;
 
 int WinX68k_Reset(void);
 int X68000_GetStorageBusMode(void);
+int X68000_SCSIU_Connect(void);
+void X68000_SCSIU_Disconnect(void);
+int X68000_SCSIU_IsConnected(void);
+const char* X68000_SCSIU_GetStatus(void);
 
 #ifndef	winx68k_gtkwarpper_h
 #define	winx68k_gtkwarpper_h

--- a/X68000 Shared/px68k/x68k/scsi.c
+++ b/X68000 Shared/px68k/x68k/scsi.c
@@ -847,21 +847,25 @@ SCSIU_WriteBlocks(DWORD lba, DWORD count, DWORD blockSize, const BYTE* buf)
  * これにより既存の SCSI_FindPartitionBootOffset / SCSI_ReadBPBFromImage 等を
  * image buffer モードと共通のコードで動かせる。
  * --------------------------------------------------------------------------------------- */
-#define SCSIU_BOOT_CACHE_BLOCKS 512  /* 512 × 512B = 256KB */
+#define SCSIU_BOOT_CACHE_BLOCKS 8192  /* 8192 × 512B = 4MB */
+#define SCSIU_READ_CHUNK_BLOCKS  128  /* max blocks per DREG-EX burst (~64KB) */
 static BYTE*  s_scsiu_boot_cache      = NULL;
 static long   s_scsiu_boot_cache_size = 0;
 
 /*
  * ブートキャッシュを物理 HDD から読み込む。
+ * DREG-EX 1 回あたり最大 SCSIU_READ_CHUNK_BLOCKS ブロック (≈64KB) に分けて転送する。
  * すでにロード済みなら即 1 を返す。
  * 戻り値: 1=成功/既ロード, 0=失敗
  */
 static int
 SCSIU_EnsureBootCache(void)
 {
-	DWORD blockSize = 512;
-	DWORD numBlocks = SCSIU_BOOT_CACHE_BLOCKS;
-	DWORD totalBytes = numBlocks * blockSize;
+	DWORD blockSize  = 512;
+	DWORD totalBlocks = SCSIU_BOOT_CACHE_BLOCKS;
+	DWORD totalBytes  = totalBlocks * blockSize;
+	DWORD chunksRead  = 0;
+	char cacheLog[128];
 
 	if (s_scsiu_boot_cache != NULL) {
 		return 1; /* 既にロード済み */
@@ -871,16 +875,31 @@ SCSIU_EnsureBootCache(void)
 	}
 	s_scsiu_boot_cache = (BYTE*)malloc(totalBytes);
 	if (s_scsiu_boot_cache == NULL) {
+		SCSI_LogText("SCSIU_CACHE: malloc failed");
 		return 0;
 	}
-	if (!SCSIU_ReadBlocks(0, numBlocks, blockSize, s_scsiu_boot_cache)) {
-		free(s_scsiu_boot_cache);
-		s_scsiu_boot_cache = NULL;
-		SCSI_LogText("SCSIU_CACHE: boot cache load failed");
-		return 0;
+
+	while (chunksRead < totalBlocks) {
+		DWORD toRead = totalBlocks - chunksRead;
+		if (toRead > SCSIU_READ_CHUNK_BLOCKS)
+			toRead = SCSIU_READ_CHUNK_BLOCKS;
+		if (!SCSIU_ReadBlocks(chunksRead, toRead, blockSize,
+		                      s_scsiu_boot_cache + chunksRead * blockSize)) {
+			free(s_scsiu_boot_cache);
+			s_scsiu_boot_cache = NULL;
+			snprintf(cacheLog, sizeof(cacheLog),
+			         "SCSIU_CACHE: load failed at block %u", (unsigned int)chunksRead);
+			SCSI_LogText(cacheLog);
+			return 0;
+		}
+		chunksRead += toRead;
 	}
+
 	s_scsiu_boot_cache_size = (long)totalBytes;
-	SCSI_LogText("SCSIU_CACHE: boot cache loaded (256KB)");
+	snprintf(cacheLog, sizeof(cacheLog),
+	         "SCSIU_CACHE: boot cache loaded (%uMB, %u blocks)",
+	         (unsigned int)(totalBytes >> 20), (unsigned int)totalBlocks);
+	SCSI_LogText(cacheLog);
 	return 1;
 }
 
@@ -4396,7 +4415,7 @@ static void SCSI_HandleDeviceCommand(void)
 		// fixed HDD as $42 here; returning $00 makes apps such as LHES/BASIC think
 		// the drive is unavailable even though plain DOS file I/O still works.
 		drvState = 0x42;
-		if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] <= 0) {
+		if (SCSI_ImgBuf() == NULL || SCSI_ImgSize() <= 0) {
 			drvState = 0x00;
 		}
 
@@ -4753,11 +4772,11 @@ static void SCSI_HandleDeviceCommand(void)
 			byteOffset = useRelative ? relByteOffset : absByteOffset;
 		}
 		byteCount = (unsigned long long)count * (unsigned long long)secSize;
-		if (s_disk_image_buffer[4] != NULL && s_disk_image_buffer_size[4] > 0) {
-			imgSize = (unsigned long long)s_disk_image_buffer_size[4];
+		if (SCSI_ImgBuf() != NULL && SCSI_ImgSize() > 0) {
+			imgSize = (unsigned long long)SCSI_ImgSize();
 		}
-		if (s_disk_image_buffer[4] != NULL &&
-		    s_disk_image_buffer_size[4] > 0 &&
+		if (SCSI_ImgBuf() != NULL &&
+		    SCSI_ImgSize() > 0 &&
 		    (byteOffset + byteCount > imgSize)) {
 			if (useRelative &&
 			    (absByteOffset + byteCount <= imgSize)) {
@@ -4801,12 +4820,51 @@ static void SCSI_HandleDeviceCommand(void)
 		SCSI_LogText(logLine);
 		/* verbose src dump removed for log space */
 
-		if (s_disk_image_buffer[4] == NULL || byteCount == 0) {
+		if (SCSI_ImgBuf() == NULL || byteCount == 0) {
 			SCSI_SetReqStatus(reqpkt, 0, 0x02);
 			SCSI_LogText("SCSI_DEV READ error (no image)");
 			break;
 		}
-		if (byteOffset + byteCount > (unsigned long long)s_disk_image_buffer_size[4]) {
+#ifdef __APPLE__
+		/* SCSI-U モード: 物理 HDD から直接ブロック読み出し */
+		if (X68000_GetStorageBusMode() == 2) {
+			if (!SCSI_IsLinearRamRange(bufAddr, (DWORD)byteCount)) {
+				SCSI_SetReqStatus(reqpkt, 0, 0x02);
+				SCSI_LogText("SCSI_DEV READ SCSIU error (buf range)");
+				break;
+			}
+			{
+				DWORD physLBA   = (DWORD)(byteOffset / secSize);
+				DWORD physBlks  = (DWORD)(byteCount  / secSize);
+				BYTE* tmpBuf    = (BYTE*)malloc((DWORD)byteCount);
+				if (tmpBuf == NULL) {
+					SCSI_SetReqStatus(reqpkt, 0, 0x02);
+					SCSI_LogText("SCSI_DEV READ SCSIU malloc fail");
+					break;
+				}
+				if (SCSIU_ReadBlocks(physLBA, physBlks, secSize, tmpBuf)) {
+					for (i = 0; i < (DWORD)byteCount; i++)
+						Memory_WriteB(bufAddr + i, tmpBuf[i]);
+				} else {
+					for (i = 0; i < (DWORD)byteCount; i++)
+						Memory_WriteB(bufAddr + i, 0x00);
+				}
+				free(tmpBuf);
+				SCSI_SetReqStatus(reqpkt, 1, 0x00);
+				{
+					char rl[96];
+					snprintf(rl, sizeof(rl),
+					         "SCSI_DEV READ SCSIU sec=%u lba=%u blks=%u",
+					         (unsigned int)startSec,
+					         (unsigned int)physLBA,
+					         (unsigned int)physBlks);
+					SCSI_LogText(rl);
+				}
+			}
+			break;
+		}
+#endif /* __APPLE__ */
+		if (byteOffset + byteCount > (unsigned long long)SCSI_ImgSize()) {
 			// Out-of-range sector: return zeros instead of error.
 			// The kernel may request sectors beyond the image (e.g. for
 			// clusters at high offsets in large partitions).  Returning
@@ -4823,7 +4881,7 @@ static void SCSI_HandleDeviceCommand(void)
 				snprintf(rl, sizeof(rl),
 				         "SCSI_DEV READ out-of-range sec=%u → zeros (off=0x%llX imgSize=%lld)",
 				         (unsigned int)startSec, byteOffset,
-				         (long long)s_disk_image_buffer_size[4]);
+				         (long long)SCSI_ImgSize());
 				SCSI_LogText(rl);
 			}
 			break;
@@ -4835,8 +4893,11 @@ static void SCSI_HandleDeviceCommand(void)
 			break;
 		}
 
-		for (i = 0; i < (DWORD)byteCount; i++) {
-			Memory_WriteB(bufAddr + i, s_disk_image_buffer[4][(DWORD)byteOffset + i]);
+		{
+			BYTE* imgPtr = SCSI_ImgBuf();
+			for (i = 0; i < (DWORD)byteCount; i++) {
+				Memory_WriteB(bufAddr + i, imgPtr[(DWORD)byteOffset + i]);
+			}
 		}
 
 		// --- FAT16 → FAT12 on-the-fly conversion ---
@@ -4857,7 +4918,7 @@ static void SCSI_HandleDeviceCommand(void)
 				DWORD imgFatBase = (DWORD)s_scsi_partition_byte_offset +
 				                   s_scsi_fat_start_sector * s_scsi_sector_size;
 				unsigned long long imgSize =
-				    (unsigned long long)s_disk_image_buffer_size[4];
+				    (unsigned long long)SCSI_ImgSize();
 
 				// Clear the buffer first
 				for (i = 0; i < (DWORD)byteCount; i++)
@@ -4870,18 +4931,19 @@ static void SCSI_HandleDeviceCommand(void)
 				DWORD lastClus  = (fat12ByteBase + (DWORD)byteCount) * 2 / 3 + 2;
 				if (lastClus > 65535) lastClus = 65535;
 				DWORD clus;
+				BYTE* imgFatPtr = SCSI_ImgBuf();
 				for (clus = firstClus; clus <= lastClus; clus++) {
 					DWORD fat12Pos = clus * 3 / 2;
 					if (fat12Pos + 1 < fat12ByteBase ||
 					    fat12Pos >= fat12ByteBase + (DWORD)byteCount)
 						continue;
 
-					// Read FAT16 entry from image (big-endian 16-bit)
+					// Read FAT16 entry from image/cache
 					DWORD f16off = imgFatBase + clus * 2;
 					WORD entry16 = 0;
-					if (f16off + 1 < imgSize) {
-						entry16 = ((WORD)s_disk_image_buffer[4][f16off] << 8) |
-						          (WORD)s_disk_image_buffer[4][f16off + 1];
+					if (imgFatPtr != NULL && f16off + 1 < (DWORD)imgSize) {
+						entry16 = ((WORD)imgFatPtr[f16off] << 8) |
+						          (WORD)imgFatPtr[f16off + 1];
 					}
 					// Clamp to 12-bit
 					WORD entry12 = entry16;
@@ -4936,11 +4998,13 @@ static void SCSI_HandleDeviceCommand(void)
 		// Verify copy integrity: compare image bytes vs memory for entry 8 (CONFIG.SYS position)
 		if (startSec == s_scsi_root_dir_start_sector && count >= 1) {
 			DWORD entOff = 8 * 32; // entry 8 = CONFIG.SYS
-			if (entOff + 32 <= byteCount) {
+			BYTE* vImgPtr = SCSI_ImgBuf();
+			if (vImgPtr != NULL && entOff + 32 <= byteCount &&
+			    (DWORD)byteOffset + entOff + 32 <= (DWORD)SCSI_ImgSize()) {
 				char vLine[256];
 				int mismatch = 0;
 				for (i = 0; i < 32; i++) {
-					BYTE imgByte = s_disk_image_buffer[4][(DWORD)byteOffset + entOff + i];
+					BYTE imgByte = vImgPtr[(DWORD)byteOffset + entOff + i];
 					BYTE memByte = Memory_ReadB(bufAddr + entOff + i);
 					if (imgByte != memByte) mismatch++;
 				}
@@ -4948,12 +5012,12 @@ static void SCSI_HandleDeviceCommand(void)
 					snprintf(vLine, sizeof(vLine),
 					         "SCSI_VERIFY MISMATCH entry8 count=%d img22-27=%02X%02X%02X%02X%02X%02X mem22-27=%02X%02X%02X%02X%02X%02X",
 					         mismatch,
-					         s_disk_image_buffer[4][(DWORD)byteOffset + entOff + 22],
-					         s_disk_image_buffer[4][(DWORD)byteOffset + entOff + 23],
-					         s_disk_image_buffer[4][(DWORD)byteOffset + entOff + 24],
-					         s_disk_image_buffer[4][(DWORD)byteOffset + entOff + 25],
-					         s_disk_image_buffer[4][(DWORD)byteOffset + entOff + 26],
-					         s_disk_image_buffer[4][(DWORD)byteOffset + entOff + 27],
+					         vImgPtr[(DWORD)byteOffset + entOff + 22],
+					         vImgPtr[(DWORD)byteOffset + entOff + 23],
+					         vImgPtr[(DWORD)byteOffset + entOff + 24],
+					         vImgPtr[(DWORD)byteOffset + entOff + 25],
+					         vImgPtr[(DWORD)byteOffset + entOff + 26],
+					         vImgPtr[(DWORD)byteOffset + entOff + 27],
 					         Memory_ReadB(bufAddr + entOff + 22),
 					         Memory_ReadB(bufAddr + entOff + 23),
 					         Memory_ReadB(bufAddr + entOff + 24),
@@ -4964,8 +5028,8 @@ static void SCSI_HandleDeviceCommand(void)
 				} else {
 					snprintf(vLine, sizeof(vLine),
 					         "SCSI_VERIFY OK entry8 img26-27=%02X%02X mem26-27=%02X%02X",
-					         s_disk_image_buffer[4][(DWORD)byteOffset + entOff + 26],
-					         s_disk_image_buffer[4][(DWORD)byteOffset + entOff + 27],
+					         vImgPtr[(DWORD)byteOffset + entOff + 26],
+					         vImgPtr[(DWORD)byteOffset + entOff + 27],
 					         Memory_ReadB(bufAddr + entOff + 26),
 					         Memory_ReadB(bufAddr + entOff + 27));
 					SCSI_LogText(vLine);
@@ -5147,11 +5211,11 @@ static void SCSI_HandleDeviceCommand(void)
 			byteOffset = useRelative ? relByteOffset : absByteOffset;
 		}
 		byteCount = (unsigned long long)count * (unsigned long long)secSize;
-		if (s_disk_image_buffer[4] != NULL && s_disk_image_buffer_size[4] > 0) {
-			imgSize = (unsigned long long)s_disk_image_buffer_size[4];
+		if (SCSI_ImgBuf() != NULL && SCSI_ImgSize() > 0) {
+			imgSize = (unsigned long long)SCSI_ImgSize();
 		}
-		if (s_disk_image_buffer[4] != NULL &&
-		    s_disk_image_buffer_size[4] > 0 &&
+		if (SCSI_ImgBuf() != NULL &&
+		    SCSI_ImgSize() > 0 &&
 		    (byteOffset + byteCount > imgSize)) {
 			if (useRelative &&
 			    (absByteOffset + byteCount <= imgSize)) {
@@ -5192,35 +5256,73 @@ static void SCSI_HandleDeviceCommand(void)
 		         (unsigned int)s_scsi_partition_byte_offset,
 		         byteCount);
 		SCSI_LogText(logLine);
-		if (s_disk_image_buffer[4] != NULL &&
-		    s_disk_image_buffer_size[4] > 0 &&
-		    byteCount >= 16 &&
-		    byteOffset + 16 <= (unsigned long long)s_disk_image_buffer_size[4]) {
-			snprintf(logLine, sizeof(logLine),
-			         "SCSI_DEV WRITE pre16=%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X",
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 0],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 1],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 2],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 3],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 4],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 5],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 6],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 7],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 8],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 9],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 10],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 11],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 12],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 13],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 14],
-			         (unsigned int)s_disk_image_buffer[4][(DWORD)byteOffset + 15]);
-			SCSI_LogText(logLine);
+		{
+			BYTE* wImgPtr = SCSI_ImgBuf();
+			if (wImgPtr != NULL &&
+			    SCSI_ImgSize() > 0 &&
+			    byteCount >= 16 &&
+			    byteOffset + 16 <= (unsigned long long)SCSI_ImgSize()) {
+				snprintf(logLine, sizeof(logLine),
+				         "SCSI_DEV WRITE pre16=%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X",
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 0],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 1],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 2],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 3],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 4],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 5],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 6],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 7],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 8],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 9],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 10],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 11],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 12],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 13],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 14],
+				         (unsigned int)wImgPtr[(DWORD)byteOffset + 15]);
+				SCSI_LogText(logLine);
+			}
 		}
 
-		if (s_disk_image_buffer[4] == NULL ||
-		    byteOffset + byteCount > (unsigned long long)s_disk_image_buffer_size[4] ||
-		    byteCount == 0 ||
+		if (SCSI_ImgBuf() == NULL || byteCount == 0 ||
 		    !SCSI_IsLinearRamRange(bufAddr, (DWORD)byteCount)) {
+			SCSI_SetReqStatus(reqpkt, 0, 0x02);
+			break;
+		}
+#ifdef __APPLE__
+		/* SCSI-U モード: 物理 HDD へ直接ブロック書き込み */
+		if (X68000_GetStorageBusMode() == 2) {
+			DWORD physLBA  = (DWORD)(byteOffset / secSize);
+			DWORD physBlks = (DWORD)(byteCount  / secSize);
+			BYTE* tmpBuf   = (BYTE*)malloc((DWORD)byteCount);
+			if (tmpBuf == NULL) {
+				SCSI_SetReqStatus(reqpkt, 0, 0x02);
+				SCSI_LogText("SCSI_DEV WRITE SCSIU malloc fail");
+				break;
+			}
+			for (i = 0; i < (DWORD)byteCount; i++)
+				tmpBuf[i] = Memory_ReadB(bufAddr + i);
+			if (!SCSIU_WriteBlocks(physLBA, physBlks, secSize, tmpBuf)) {
+				free(tmpBuf);
+				SCSI_SetReqStatus(reqpkt, 0, 0x02);
+				SCSI_LogText("SCSI_DEV WRITE SCSIU failed");
+				break;
+			}
+			free(tmpBuf);
+			SCSI_SetReqStatus(reqpkt, 1, 0x00);
+			{
+				char wl[96];
+				snprintf(wl, sizeof(wl),
+				         "SCSI_DEV WRITE SCSIU sec=%u lba=%u blks=%u",
+				         (unsigned int)startSec,
+				         (unsigned int)physLBA,
+				         (unsigned int)physBlks);
+				SCSI_LogText(wl);
+			}
+			break;
+		}
+#endif /* __APPLE__ */
+		if (byteOffset + byteCount > (unsigned long long)SCSI_ImgSize()) {
 			SCSI_SetReqStatus(reqpkt, 0, 0x02);
 			break;
 		}

--- a/X68000 Shared/px68k/x68k/scsi.c
+++ b/X68000 Shared/px68k/x68k/scsi.c
@@ -108,6 +108,7 @@ static int SCSIU_EnsureBootCache(void);
 static int SCSIU_ReadCapacity(DWORD* outLastLBA, DWORD* outBlockSize);
 static void SCSIU_ResetBootCache(void);
 static void SCSIU_InvalidateBootCacheRange(DWORD lba, DWORD count, DWORD blockSize);
+static DWORD SCSIU_GetBlockSize(void);
 #endif
 static BYTE* SCSI_ImgBuf(void);
 static long  SCSI_ImgSize(void);
@@ -846,14 +847,15 @@ SCSIU_WriteBlocks(DWORD lba, DWORD count, DWORD blockSize, const BYTE* buf)
 
 /* ---------------------------------------------------------------------------------------
  * SCSI-U ブートキャッシュ
- * 物理 HDD の先頭 SCSIU_BOOT_CACHE_BLOCKS ブロックをキャッシュする。
+ * 物理 HDD の先頭約 4MB をキャッシュする。
  * これにより既存の SCSI_FindPartitionBootOffset / SCSI_ReadBPBFromImage 等を
  * image buffer モードと共通のコードで動かせる。
  * --------------------------------------------------------------------------------------- */
-#define SCSIU_BOOT_CACHE_BLOCKS 8192  /* 8192 × 512B = 4MB */
-#define SCSIU_READ_CHUNK_BLOCKS  128  /* max blocks per DREG-EX burst (~64KB) */
+#define SCSIU_BOOT_CACHE_TARGET_BYTES (4 * 1024 * 1024)
 static BYTE*  s_scsiu_boot_cache      = NULL;
 static long   s_scsiu_boot_cache_size = 0;
+static DWORD  s_scsiu_reported_block_size = 512;
+static int    s_scsiu_capacity_valid = 0;
 
 static void
 SCSIU_ResetBootCache(void)
@@ -863,6 +865,8 @@ SCSIU_ResetBootCache(void)
 		s_scsiu_boot_cache = NULL;
 	}
 	s_scsiu_boot_cache_size = 0;
+	s_scsiu_reported_block_size = 512;
+	s_scsiu_capacity_valid = 0;
 }
 
 static void
@@ -892,19 +896,35 @@ SCSIU_InvalidateBootCacheRange(DWORD lba, DWORD count, DWORD blockSize)
 	}
 }
 
+static DWORD
+SCSIU_GetBlockSize(void)
+{
+	DWORD lastLBA = 0;
+	DWORD blockSize = 0;
+
+	if (s_scsiu_capacity_valid && s_scsiu_reported_block_size != 0) {
+		return s_scsiu_reported_block_size;
+	}
+	if (s_scsi_u_bridge.connected && SCSIU_ReadCapacity(&lastLBA, &blockSize) && blockSize != 0) {
+		return blockSize;
+	}
+	return (s_scsiu_reported_block_size != 0) ? s_scsiu_reported_block_size : 512;
+}
+
 /*
  * ブートキャッシュを物理 HDD から読み込む。
- * DREG-EX 1 回あたり最大 SCSIU_READ_CHUNK_BLOCKS ブロック (≈64KB) に分けて転送する。
+ * DREG-EX 1 回あたり約 64KB 以下に分けて転送する。
  * すでにロード済みなら即 1 を返す。
  * 戻り値: 1=成功/既ロード, 0=失敗
  */
 static int
 SCSIU_EnsureBootCache(void)
 {
-	DWORD blockSize  = 512;
-	DWORD totalBlocks = SCSIU_BOOT_CACHE_BLOCKS;
-	DWORD totalBytes  = totalBlocks * blockSize;
+	DWORD blockSize;
+	DWORD totalBlocks;
+	DWORD totalBytes;
 	DWORD chunksRead  = 0;
+	DWORD chunkBlocks;
 	char cacheLog[128];
 
 	if (s_scsiu_boot_cache != NULL) {
@@ -912,6 +932,19 @@ SCSIU_EnsureBootCache(void)
 	}
 	if (!s_scsi_u_bridge.connected) {
 		return 0;
+	}
+	blockSize = SCSIU_GetBlockSize();
+	if (blockSize == 0) {
+		blockSize = 512;
+	}
+	totalBlocks = (DWORD)(((unsigned long long)SCSIU_BOOT_CACHE_TARGET_BYTES + blockSize - 1) / blockSize);
+	if (totalBlocks == 0) {
+		totalBlocks = 1;
+	}
+	totalBytes = totalBlocks * blockSize;
+	chunkBlocks = 0xFFFFu / blockSize;
+	if (chunkBlocks == 0) {
+		chunkBlocks = 1;
 	}
 	s_scsiu_boot_cache = (BYTE*)malloc(totalBytes);
 	if (s_scsiu_boot_cache == NULL) {
@@ -921,12 +954,11 @@ SCSIU_EnsureBootCache(void)
 
 	while (chunksRead < totalBlocks) {
 		DWORD toRead = totalBlocks - chunksRead;
-		if (toRead > SCSIU_READ_CHUNK_BLOCKS)
-			toRead = SCSIU_READ_CHUNK_BLOCKS;
+		if (toRead > chunkBlocks)
+			toRead = chunkBlocks;
 		if (!SCSIU_ReadBlocks(chunksRead, toRead, blockSize,
 		                      s_scsiu_boot_cache + chunksRead * blockSize)) {
-			free(s_scsiu_boot_cache);
-			s_scsiu_boot_cache = NULL;
+			SCSIU_ResetBootCache();
 			snprintf(cacheLog, sizeof(cacheLog),
 			         "SCSIU_CACHE: load failed at block %u", (unsigned int)chunksRead);
 			SCSI_LogText(cacheLog);
@@ -937,8 +969,10 @@ SCSIU_EnsureBootCache(void)
 
 	s_scsiu_boot_cache_size = (long)totalBytes;
 	snprintf(cacheLog, sizeof(cacheLog),
-	         "SCSIU_CACHE: boot cache loaded (%uMB, %u blocks)",
-	         (unsigned int)(totalBytes >> 20), (unsigned int)totalBlocks);
+	         "SCSIU_CACHE: boot cache loaded (%uMB, %u blocks, blockSize=%u)",
+	         (unsigned int)(totalBytes >> 20),
+	         (unsigned int)totalBlocks,
+	         (unsigned int)blockSize);
 	SCSI_LogText(cacheLog);
 	return 1;
 }
@@ -1013,6 +1047,8 @@ SCSIU_ReadCapacity(DWORD* outLastLBA, DWORD* outBlockSize)
 	                ((DWORD)resp[2] <<  8) |  (DWORD)resp[3];
 	*outBlockSize = ((DWORD)resp[4] << 24) | ((DWORD)resp[5] << 16) |
 	                ((DWORD)resp[6] <<  8) |  (DWORD)resp[7];
+	s_scsiu_reported_block_size = (*outBlockSize != 0) ? *outBlockSize : 512;
+	s_scsiu_capacity_valid = 1;
 	return 1;
 }
 
@@ -1996,7 +2032,7 @@ static void SCSI_HandleBoot(void)
 
 	blockSize = SCSI_GetImageBlockSize();
 	if (blockSize == 0) {
-		blockSize = 512;
+		blockSize = (X68000_GetStorageBusMode() == 2) ? SCSIU_GetBlockSize() : 512;
 	}
 	// SCSI HDD boot code lives at LBA2.  X68SCSI1 containers place the payload
 	// (virtual LBA2) at 0x400; raw images need an explicit +2 sector offset.
@@ -2214,7 +2250,7 @@ void SCSI_InjectBoot(void)
 
 	blockSize = SCSI_GetImageBlockSize();
 	if (blockSize == 0) {
-		blockSize = 512;
+		blockSize = (X68000_GetStorageBusMode() == 2) ? SCSIU_GetBlockSize() : 512;
 	}
 	bootOffset = SCSI_GetPayloadOffset();
 	if (bootOffset == 0) {
@@ -2876,13 +2912,19 @@ static void SCSI_HandleIOCS(BYTE cmd)
 				break;
 			}
 			/* SPC READ CAPACITY(10) で実際の容量を取得する */
-			blockSize = 512;
+			blockSize = SCSIU_GetBlockSize();
 			if (SCSIU_ReadCapacity(&lastLBA, &blockSize)) {
 				totalBlocks = lastLBA + 1;
 			} else {
 				/* 失敗時フォールバック: 4GB 分 */
-				blockSize = 512;
-				totalBlocks = 0x800000;
+				unsigned long long fallbackBytes = 4ULL * 1024ULL * 1024ULL * 1024ULL;
+				if (blockSize == 0) {
+					blockSize = 512;
+				}
+				totalBlocks = (DWORD)(fallbackBytes / blockSize);
+				if (totalBlocks == 0) {
+					totalBlocks = 1;
+				}
 			}
 			Memory_WriteB(a1 + 0, (BYTE)(((totalBlocks - 1) >> 24) & 0xff));
 			Memory_WriteB(a1 + 1, (BYTE)(((totalBlocks - 1) >> 16) & 0xff));
@@ -3117,7 +3159,7 @@ static void SCSI_HandleIOCS(BYTE cmd)
 				            (s_spc_cdb[2] << 8) | s_spc_cdb[3];
 				DWORD blocks = s_spc_cdb[4];
 				if (blocks == 0) blocks = 256;
-				DWORD blockSize = 512;
+				DWORD blockSize = (X68000_GetStorageBusMode() == 2) ? SCSIU_GetBlockSize() : 512;
 				DWORD byteOff = lba * blockSize;
 				DWORD byteLen = blocks * blockSize;
 				DWORD ri;
@@ -3150,7 +3192,7 @@ static void SCSI_HandleIOCS(BYTE cmd)
 				            ((DWORD)s_spc_cdb[4] << 8) |
 				            (DWORD)s_spc_cdb[5];
 				DWORD blocks = ((DWORD)s_spc_cdb[7] << 8) | s_spc_cdb[8];
-				DWORD blockSize = 512;
+				DWORD blockSize = (X68000_GetStorageBusMode() == 2) ? SCSIU_GetBlockSize() : 512;
 				DWORD byteOff = lba * blockSize;
 				DWORD byteLen = blocks * blockSize;
 				DWORD ri;
@@ -3196,7 +3238,7 @@ static void SCSI_HandleIOCS(BYTE cmd)
 			}
 			case 0x25: {  // READ CAPACITY
 				DWORD totalBlocks = 0;
-				DWORD capBlockSize = 512;
+				DWORD capBlockSize = (X68000_GetStorageBusMode() == 2) ? SCSIU_GetBlockSize() : 512;
 				BYTE cap[8];
 #ifdef __APPLE__
 				if (X68000_GetStorageBusMode() == 2) {
@@ -3277,7 +3319,7 @@ static void SCSI_HandleIOCS(BYTE cmd)
 			BYTE scsiCmd = s_spc_cdb[0];
 			if (scsiCmd == 0x0A || scsiCmd == 0x2A) {
 				// WRITE(6) or WRITE(10)
-				DWORD lba, blocks, blockSize = 512;
+				DWORD lba, blocks, blockSize = (X68000_GetStorageBusMode() == 2) ? SCSIU_GetBlockSize() : 512;
 				DWORD byteOff, byteLen;
 				if (scsiCmd == 0x0A) {
 					lba = ((s_spc_cdb[1] & 0x1F) << 16) |

--- a/X68000 Shared/px68k/x68k/scsi.c
+++ b/X68000 Shared/px68k/x68k/scsi.c
@@ -104,7 +104,11 @@ static void SCSIU_SendSPCReg(BYTE regAddr, BYTE val);
 static int SCSIU_ExecDregBurst(BYTE* buf, DWORD maxLen);
 static int SCSIU_ReadBlocks(DWORD lba, DWORD count, DWORD blockSize, BYTE* buf);
 static int SCSIU_WriteBlocks(DWORD lba, DWORD count, DWORD blockSize, const BYTE* buf);
+static int SCSIU_EnsureBootCache(void);
+static int SCSIU_ReadCapacity(DWORD* outLastLBA, DWORD* outBlockSize);
 #endif
+static BYTE* SCSI_ImgBuf(void);
+static long  SCSI_ImgSize(void);
 
 
 // Minimal SPC (MB89352) register state for driver initialization.
@@ -837,7 +841,149 @@ SCSIU_WriteBlocks(DWORD lba, DWORD count, DWORD blockSize, const BYTE* buf)
 	return 1;
 }
 
+/* ---------------------------------------------------------------------------------------
+ * SCSI-U ブートキャッシュ
+ * 物理 HDD の先頭 SCSIU_BOOT_CACHE_BLOCKS ブロックをキャッシュする。
+ * これにより既存の SCSI_FindPartitionBootOffset / SCSI_ReadBPBFromImage 等を
+ * image buffer モードと共通のコードで動かせる。
+ * --------------------------------------------------------------------------------------- */
+#define SCSIU_BOOT_CACHE_BLOCKS 512  /* 512 × 512B = 256KB */
+static BYTE*  s_scsiu_boot_cache      = NULL;
+static long   s_scsiu_boot_cache_size = 0;
+
+/*
+ * ブートキャッシュを物理 HDD から読み込む。
+ * すでにロード済みなら即 1 を返す。
+ * 戻り値: 1=成功/既ロード, 0=失敗
+ */
+static int
+SCSIU_EnsureBootCache(void)
+{
+	DWORD blockSize = 512;
+	DWORD numBlocks = SCSIU_BOOT_CACHE_BLOCKS;
+	DWORD totalBytes = numBlocks * blockSize;
+
+	if (s_scsiu_boot_cache != NULL) {
+		return 1; /* 既にロード済み */
+	}
+	if (!s_scsi_u_bridge.connected) {
+		return 0;
+	}
+	s_scsiu_boot_cache = (BYTE*)malloc(totalBytes);
+	if (s_scsiu_boot_cache == NULL) {
+		return 0;
+	}
+	if (!SCSIU_ReadBlocks(0, numBlocks, blockSize, s_scsiu_boot_cache)) {
+		free(s_scsiu_boot_cache);
+		s_scsiu_boot_cache = NULL;
+		SCSI_LogText("SCSIU_CACHE: boot cache load failed");
+		return 0;
+	}
+	s_scsiu_boot_cache_size = (long)totalBytes;
+	SCSI_LogText("SCSIU_CACHE: boot cache loaded (256KB)");
+	return 1;
+}
+
+/*
+ * SPC READ CAPACITY(10) を実行して実際のディスク容量を取得する。
+ * outLastLBA: 最後の LBA (ブロック数 - 1)
+ * outBlockSize: バイト/ブロック
+ * 戻り値: 1=成功, 0=失敗
+ */
+static int
+SCSIU_ReadCapacity(DWORD* outLastLBA, DWORD* outBlockSize)
+{
+	BYTE cdb[10];
+	BYTE resp[8];
+	int received;
+
+	if (!s_scsi_u_bridge.connected || s_scsi_u_bridge.control_fd < 0) {
+		return 0;
+	}
+
+	/* SPC 初期化 */
+	SCSIU_SendSPCReg(0x03/*SCTL*/, 0x14);
+	SCSIU_SendSPCReg(0x01/*BDID*/, 0x40);
+
+	/* ARBITRATION + SELECTION */
+	SCSIU_SendSPCReg(0x11/*PCTL*/, 0x00);
+	SCSIU_SendSPCReg(0x17/*TEMP*/, 0x01);
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x04);
+	usleep(2000);
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x28);
+	if (!SCSIU_WaitINTS(0x08, 2000000)) {
+		return 0;
+	}
+
+	/* READ CAPACITY(10) CDB */
+	memset(cdb, 0, sizeof(cdb));
+	cdb[0] = 0x25; /* READ CAPACITY(10) */
+	SCSIU_SendSPCReg(0x11/*PCTL*/, 0x02);
+	{
+		int k;
+		for (k = 0; k < 10; ++k) {
+			SCSIU_SendSPCReg(0x15/*DREG*/, cdb[k]);
+		}
+	}
+
+	/* DATA IN フェーズ待ち */
+	if (!SCSIU_WaitINTS(0x08, 5000000)) {
+		return 0;
+	}
+
+	/* 8バイト受信 */
+	SCSIU_SendSPCReg(0x19/*TCH*/, 0x00);
+	SCSIU_SendSPCReg(0x1B/*TCM*/, 0x00);
+	SCSIU_SendSPCReg(0x1D/*TCL*/, 0x08);
+	SCSIU_SendSPCReg(0x11/*PCTL*/, 0x01);
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x84);
+
+	received = SCSIU_ExecDregBurst(resp, 8);
+	if (received < 8) {
+		return 0;
+	}
+
+	/* STATUS + MESSAGE */
+	SCSIU_WaitINTS(0x08, 2000000);
+	SCSIU_ExecSPCReg(0x15/*DREG*/);
+	SCSIU_WaitINTS(0x08, 1000000);
+	SCSIU_ExecSPCReg(0x15/*DREG*/);
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x28);
+
+	*outLastLBA   = ((DWORD)resp[0] << 24) | ((DWORD)resp[1] << 16) |
+	                ((DWORD)resp[2] <<  8) |  (DWORD)resp[3];
+	*outBlockSize = ((DWORD)resp[4] << 24) | ((DWORD)resp[5] << 16) |
+	                ((DWORD)resp[6] <<  8) |  (DWORD)resp[7];
+	return 1;
+}
+
 #endif /* __APPLE__ */
+
+/* ---------------------------------------------------------------------------------------
+ * バスモードに応じたイメージバッファポインタ/サイズ取得ヘルパー。
+ * SCSI-U モードではブートキャッシュを返す。
+ * --------------------------------------------------------------------------------------- */
+static BYTE*
+SCSI_ImgBuf(void)
+{
+#ifdef __APPLE__
+	if (X68000_GetStorageBusMode() == 2) {
+		return s_scsiu_boot_cache;
+	}
+#endif
+	return s_disk_image_buffer[4];
+}
+
+static long
+SCSI_ImgSize(void)
+{
+#ifdef __APPLE__
+	if (X68000_GetStorageBusMode() == 2) {
+		return s_scsiu_boot_cache_size;
+	}
+#endif
+	return s_disk_image_buffer_size[4];
+}
 
 // ---------------------------------------------------------------------------------------
 //  合成SCSI ROM (外付けSCSI CZ-6BS1互換: $EA0000-$EA1FFF)
@@ -1283,12 +1429,12 @@ static DWORD SCSI_GetPayloadOffset(void)
 	BYTE* buf;
 	long size;
 
-	if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] < 8) {
+	if (SCSI_ImgBuf() == NULL || SCSI_ImgSize() < 8) {
 		return 0;
 	}
 
-	buf = s_disk_image_buffer[4];
-	size = s_disk_image_buffer_size[4];
+	buf = SCSI_ImgBuf();
+	size = SCSI_ImgSize();
 
 	// Standard container header.
 	if (memcmp(buf, "X68SCSI1", 8) == 0) {
@@ -1374,11 +1520,11 @@ static DWORD SCSI_GetImageBlockSize(void)
 	int hasPart512;
 	int hasPart1024;
 
-	if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] < 16) {
+	if (SCSI_ImgBuf() == NULL || SCSI_ImgSize() < 16) {
 		return 512;
 	}
-	buf = s_disk_image_buffer[4];
-	size = s_disk_image_buffer_size[4];
+	buf = SCSI_ImgBuf();
+	size = SCSI_ImgSize();
 
 	if (memcmp(buf, "X68SCSI1", 8) == 0 || memcmp(buf + 1, "68SCSI1", 7) == 0) {
 		headerBlockSize = ((DWORD)buf[8] << 8) | (DWORD)buf[9];
@@ -1766,14 +1912,26 @@ static void SCSI_HandleBoot(void)
 
 	printf("SCSI_HandleBoot: Attempting SCSI boot...\n");
 
-	if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] <= 0) {
+#ifdef __APPLE__
+	if (X68000_GetStorageBusMode() == 2) {
+		/* SCSI-U モード: 物理 HDD の先頭を USB 経由で読み込む */
+		if (!SCSIU_EnsureBootCache()) {
+			printf("SCSI_HandleBoot: SCSI-U boot cache load failed\n");
+			SCSI_LogText("SCSIU_BOOT: boot cache load failed");
+			C68k_Set_DReg(&C68K, 0, 0xFFFFFFFF);
+			return;
+		}
+	}
+#endif
+
+	if (SCSI_ImgBuf() == NULL || SCSI_ImgSize() <= 0) {
 		printf("SCSI_HandleBoot: No HDD image loaded\n");
 		SCSI_LogText("SCSI_BOOT: no HDD image");
 		C68k_Set_DReg(&C68K, 0, 0xFFFFFFFF);
 		return;
 	}
-	imgBuf = s_disk_image_buffer[4];
-	imgSize = (DWORD)s_disk_image_buffer_size[4];
+	imgBuf = SCSI_ImgBuf();
+	imgSize = (DWORD)SCSI_ImgSize();
 
 	blockSize = SCSI_GetImageBlockSize();
 	if (blockSize == 0) {
@@ -1846,8 +2004,8 @@ static void SCSI_HandleBoot(void)
 
 	// ブートコードとして先頭8セクタをロード
 	bootSize = blockSize * 8;
-	if (bootOffset + bootSize > (DWORD)s_disk_image_buffer_size[4]) {
-		bootSize = (DWORD)s_disk_image_buffer_size[4] - bootOffset;
+	if (bootOffset + bootSize > (DWORD)SCSI_ImgSize()) {
+		bootSize = (DWORD)SCSI_ImgSize() - bootOffset;
 	}
 	if (bootSize < 16) {
 		snprintf(bootLog, sizeof(bootLog),
@@ -1859,20 +2017,20 @@ static void SCSI_HandleBoot(void)
 	}
 
 	// M68000 メモリにコピー (バイト単位で書き込み、エンディアン考慮)
-	for (i = 0; i < bootSize; i++) {
-		Memory_WriteB(destAddr + i, s_disk_image_buffer[4][bootOffset + i]);
+	{
+		BYTE* src = SCSI_ImgBuf();
+		for (i = 0; i < bootSize; i++) {
+			Memory_WriteB(destAddr + i, src[bootOffset + i]);
+		}
+		snprintf(bootLog, sizeof(bootLog),
+		         "SCSI_BOOT: load=%u offset=0x%X lbaBase=%u blk=%u d5=%u first=%02X%02X%02X%02X",
+		         (unsigned int)bootSize, (unsigned int)bootOffset,
+		         (unsigned int)bootBaseLBA,
+		         (unsigned int)blockSize,
+		         (unsigned int)d5Exp,
+		         src[bootOffset + 0], src[bootOffset + 1],
+		         src[bootOffset + 2], src[bootOffset + 3]);
 	}
-
-	snprintf(bootLog, sizeof(bootLog),
-	         "SCSI_BOOT: load=%u offset=0x%X lbaBase=%u blk=%u d5=%u first=%02X%02X%02X%02X",
-	         (unsigned int)bootSize, (unsigned int)bootOffset,
-	         (unsigned int)bootBaseLBA,
-	         (unsigned int)blockSize,
-	         (unsigned int)d5Exp,
-	         s_disk_image_buffer[4][bootOffset + 0],
-	         s_disk_image_buffer[4][bootOffset + 1],
-	         s_disk_image_buffer[4][bootOffset + 2],
-	         s_disk_image_buffer[4][bootOffset + 3]);
 	SCSI_LogText(bootLog);
 
 	// Real SCSI IPL passes sector-size code in d5 and target ID in d1.
@@ -1948,8 +2106,20 @@ void SCSI_InjectBoot(void)
 	SCSI_LogText("SCSI_INJECT_BOOT: IPL ROM init complete, injecting SCSI boot");
 	printf("SCSI_InjectBoot: IPL ROM init complete, injecting SCSI boot...\n");
 
-	// Verify buffer integrity at BPB area
-	if (s_disk_image_buffer[4] != NULL && s_disk_image_buffer_size[4] > 0x8020) {
+#ifdef __APPLE__
+	if (X68000_GetStorageBusMode() == 2) {
+		/* SCSI-U モード: ブートキャッシュをロード */
+		if (!SCSIU_EnsureBootCache()) {
+			printf("SCSI_InjectBoot: SCSI-U boot cache load failed\n");
+			SCSI_LogText("SCSIU_INJECT: boot cache load failed");
+			return;
+		}
+	}
+#endif
+
+	// Verify buffer integrity at BPB area (image mode only — SCSI-U cache may be smaller)
+	if (s_disk_image_buffer[4] != NULL && s_disk_image_buffer_size[4] > 0x8020
+	    && X68000_GetStorageBusMode() != 2) {
 		char vb[256];
 		snprintf(vb, sizeof(vb),
 		         "BUF_VERIFY_INJECT @0x8012: %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X",
@@ -1961,24 +2131,25 @@ void SCSI_InjectBoot(void)
 		         s_disk_image_buffer[4][0x801C], s_disk_image_buffer[4][0x801D],
 		         s_disk_image_buffer[4][0x801E], s_disk_image_buffer[4][0x801F]);
 		SCSI_LogText(vb);
-		// Also check root dir entry 8 (CONFIG.SYS)
-		snprintf(vb, sizeof(vb),
-		         "BUF_VERIFY_INJECT rootdir8@0x40D16: %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X",
-		         s_disk_image_buffer[4][0x40D16], s_disk_image_buffer[4][0x40D17],
-		         s_disk_image_buffer[4][0x40D18], s_disk_image_buffer[4][0x40D19],
-		         s_disk_image_buffer[4][0x40D1A], s_disk_image_buffer[4][0x40D1B],
-		         s_disk_image_buffer[4][0x40D1C], s_disk_image_buffer[4][0x40D1D],
-		         s_disk_image_buffer[4][0x40D1E], s_disk_image_buffer[4][0x40D1F]);
-		SCSI_LogText(vb);
+		if (s_disk_image_buffer_size[4] > 0x40D26) {
+			snprintf(vb, sizeof(vb),
+			         "BUF_VERIFY_INJECT rootdir8@0x40D16: %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X",
+			         s_disk_image_buffer[4][0x40D16], s_disk_image_buffer[4][0x40D17],
+			         s_disk_image_buffer[4][0x40D18], s_disk_image_buffer[4][0x40D19],
+			         s_disk_image_buffer[4][0x40D1A], s_disk_image_buffer[4][0x40D1B],
+			         s_disk_image_buffer[4][0x40D1C], s_disk_image_buffer[4][0x40D1D],
+			         s_disk_image_buffer[4][0x40D1E], s_disk_image_buffer[4][0x40D1F]);
+			SCSI_LogText(vb);
+		}
 	}
 
-	if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] <= 0) {
+	if (SCSI_ImgBuf() == NULL || SCSI_ImgSize() <= 0) {
 		printf("SCSI_InjectBoot: No HDD image loaded\n");
 		SCSI_LogText("SCSI_INJECT_BOOT: no HDD image - aborting");
 		return;
 	}
-	imgBuf = s_disk_image_buffer[4];
-	imgSize = (DWORD)s_disk_image_buffer_size[4];
+	imgBuf = SCSI_ImgBuf();
+	imgSize = (DWORD)SCSI_ImgSize();
 
 	blockSize = SCSI_GetImageBlockSize();
 	if (blockSize == 0) {
@@ -2632,9 +2803,8 @@ static void SCSI_HandleIOCS(BYTE cmd)
 		DWORD totalBlocks;
 
 		if (X68000_GetStorageBusMode() == 2) {
-			/* SCSI-U モード: SPC READ CAPACITY(10) で実際の値を取得する。
-			 * 暫定実装: デバイス接続確認のみ行い、固定 blockSize / 容量を返す。
-			 * TODO: SPC READ CAPACITY コマンドで実際の値を取得する。 */
+#ifdef __APPLE__
+			DWORD lastLBA = 0;
 			if (!SCSIU_IsConnected()) {
 				result = 0xFFFFFFFF;
 				break;
@@ -2643,9 +2813,15 @@ static void SCSI_HandleIOCS(BYTE cmd)
 				result = 0xFFFFFFFF;
 				break;
 			}
-			/* ブロックサイズは 512 バイト固定、容量は 4GB - 1 ブロック */
+			/* SPC READ CAPACITY(10) で実際の容量を取得する */
 			blockSize = 512;
-			totalBlocks = 0x800000; /* 4GB / 512 = 8388608 ブロック */
+			if (SCSIU_ReadCapacity(&lastLBA, &blockSize)) {
+				totalBlocks = lastLBA + 1;
+			} else {
+				/* 失敗時フォールバック: 4GB 分 */
+				blockSize = 512;
+				totalBlocks = 0x800000;
+			}
 			Memory_WriteB(a1 + 0, (BYTE)(((totalBlocks - 1) >> 24) & 0xff));
 			Memory_WriteB(a1 + 1, (BYTE)(((totalBlocks - 1) >> 16) & 0xff));
 			Memory_WriteB(a1 + 2, (BYTE)(((totalBlocks - 1) >>  8) & 0xff));
@@ -2655,11 +2831,15 @@ static void SCSI_HandleIOCS(BYTE cmd)
 			Memory_WriteB(a1 + 6, (BYTE)((blockSize >>  8) & 0xff));
 			Memory_WriteB(a1 + 7, (BYTE)(blockSize & 0xff));
 			snprintf(logLine, sizeof(logLine),
-			         "SCSIU_READCAP blocks=%u blockSize=%u (stub)",
-			         (unsigned int)totalBlocks, (unsigned int)blockSize);
+			         "SCSIU_READCAP lastLBA=%u blockSize=%u",
+			         (unsigned int)(totalBlocks - 1), (unsigned int)blockSize);
 			SCSI_LogText(logLine);
 			result = 0;
 			break;
+#else
+			result = 0xFFFFFFFF;
+			break;
+#endif
 		}
 
 		dataOffset = SCSI_GetIocsDataOffset();
@@ -2827,7 +3007,8 @@ static void SCSI_HandleIOCS(BYTE cmd)
 		s_spc_cmd_valid = 0;
 		s_spc_status_byte = 0x00;   // GOOD
 		s_spc_message_byte = 0x00;  // Command Complete
-		if (s_disk_image_buffer[4] != NULL && s_disk_image_buffer_size[4] > 0) {
+		if ((X68000_GetStorageBusMode() == 2 && SCSIU_IsConnected()) ||
+		    (s_disk_image_buffer[4] != NULL && s_disk_image_buffer_size[4] > 0)) {
 			s_spc_regs[0x09] = 0x01;  // INTS: SEL complete
 			result = 0;
 		} else {
@@ -2879,6 +3060,18 @@ static void SCSI_HandleIOCS(BYTE cmd)
 				DWORD byteLen = blocks * blockSize;
 				DWORD ri;
 				if (xferLen < byteLen) byteLen = xferLen;
+#ifdef __APPLE__
+				if (X68000_GetStorageBusMode() == 2) {
+					BYTE* tmpR6 = (BYTE*)malloc(byteLen);
+					if (tmpR6 && SCSIU_ReadBlocks(lba, byteLen / blockSize, blockSize, tmpR6)) {
+						for (ri = 0; ri < byteLen; ri++)
+							Memory_WriteB(dstAddr + ri, tmpR6[ri]);
+					} else {
+						for (ri = 0; ri < byteLen; ri++) Memory_WriteB(dstAddr + ri, 0x00);
+					}
+					free(tmpR6);
+				} else
+#endif
 				if (s_disk_image_buffer[4] &&
 				    byteOff + byteLen <= (DWORD)s_disk_image_buffer_size[4]) {
 					for (ri = 0; ri < byteLen; ri++)
@@ -2900,6 +3093,18 @@ static void SCSI_HandleIOCS(BYTE cmd)
 				DWORD byteLen = blocks * blockSize;
 				DWORD ri;
 				if (xferLen < byteLen) byteLen = xferLen;
+#ifdef __APPLE__
+				if (X68000_GetStorageBusMode() == 2) {
+					BYTE* tmpR10 = (BYTE*)malloc(byteLen);
+					if (tmpR10 && blocks > 0 && SCSIU_ReadBlocks(lba, blocks, blockSize, tmpR10)) {
+						for (ri = 0; ri < byteLen; ri++)
+							Memory_WriteB(dstAddr + ri, tmpR10[ri]);
+					} else {
+						for (ri = 0; ri < byteLen; ri++) Memory_WriteB(dstAddr + ri, 0x00);
+					}
+					free(tmpR10);
+				} else
+#endif
 				if (s_disk_image_buffer[4] &&
 				    byteOff + byteLen <= (DWORD)s_disk_image_buffer_size[4]) {
 					for (ri = 0; ri < byteLen; ri++)
@@ -2929,15 +3134,27 @@ static void SCSI_HandleIOCS(BYTE cmd)
 			}
 			case 0x25: {  // READ CAPACITY
 				DWORD totalBlocks = 0;
+				DWORD capBlockSize = 512;
 				BYTE cap[8];
-				if (s_disk_image_buffer[4])
+#ifdef __APPLE__
+				if (X68000_GetStorageBusMode() == 2) {
+					DWORD lastLBA = 0;
+					SCSIU_ReadCapacity(&lastLBA, &capBlockSize);
+					totalBlocks = lastLBA; /* already 0-based last LBA */
+				} else
+#endif
+				if (s_disk_image_buffer[4]) {
 					totalBlocks = (DWORD)(s_disk_image_buffer_size[4] / 512);
-				if (totalBlocks > 0) totalBlocks--;
+					if (totalBlocks > 0) totalBlocks--;
+				}
 				cap[0] = (totalBlocks >> 24) & 0xFF;
 				cap[1] = (totalBlocks >> 16) & 0xFF;
 				cap[2] = (totalBlocks >> 8) & 0xFF;
 				cap[3] = totalBlocks & 0xFF;
-				cap[4] = 0; cap[5] = 0; cap[6] = 0x02; cap[7] = 0x00; // 512 bytes
+				cap[4] = (capBlockSize >> 24) & 0xFF;
+				cap[5] = (capBlockSize >> 16) & 0xFF;
+				cap[6] = (capBlockSize >>  8) & 0xFF;
+				cap[7] = capBlockSize & 0xFF;
 				{
 					DWORD copyLen = (xferLen < 8) ? xferLen : 8;
 					DWORD ri;
@@ -3452,11 +3669,11 @@ static DWORD SCSI_DetectBootBlockSize(DWORD bootOffset)
 	DWORD size;
 	DWORD i;
 
-	if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] <= 0) {
+	if (SCSI_ImgBuf() == NULL || SCSI_ImgSize() <= 0) {
 		return 0;
 	}
-	buf = s_disk_image_buffer[4];
-	size = (DWORD)s_disk_image_buffer_size[4];
+	buf = SCSI_ImgBuf();
+	size = (DWORD)SCSI_ImgSize();
 	for (i = 0; i < (DWORD)(sizeof(bpbOffsets) / sizeof(bpbOffsets[0])); i++) {
 		DWORD pos = bootOffset + bpbOffsets[i];
 		WORD bytesPerSec;
@@ -3484,11 +3701,11 @@ static DWORD SCSI_FindPartitionBootOffset(void)
 	DWORD partTableOffset;
 	DWORD i;
 
-	if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] < 0x1000) {
+	if (SCSI_ImgBuf() == NULL || SCSI_ImgSize() < 0x1000) {
 		return 0;
 	}
-	buf = s_disk_image_buffer[4];
-	size = s_disk_image_buffer_size[4];
+	buf = SCSI_ImgBuf();
+	size = SCSI_ImgSize();
 
 	// IOCS/boot pathと同じ判定を使い、raw/X68SCSI1で一貫させる
 	physSectorSize = SCSI_GetImageBlockSize();
@@ -3552,11 +3769,11 @@ static int SCSI_ReadBPBFromImage(BYTE* outBpb, DWORD* outPartOffset)
 	BYTE rawBpb[36];
 	WORD bytesPerSec = 0;
 
-	if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] <= 0) {
+	if (SCSI_ImgBuf() == NULL || SCSI_ImgSize() <= 0) {
 		return 0;
 	}
-	buf = s_disk_image_buffer[4];
-	size = s_disk_image_buffer_size[4];
+	buf = SCSI_ImgBuf();
+	size = SCSI_ImgSize();
 
 	bootOffset = SCSI_FindPartitionBootOffset();
 	if (bootOffset == 0 || bootOffset + 0x30 > (DWORD)size) {

--- a/X68000 Shared/px68k/x68k/scsi.c
+++ b/X68000 Shared/px68k/x68k/scsi.c
@@ -106,6 +106,8 @@ static int SCSIU_ReadBlocks(DWORD lba, DWORD count, DWORD blockSize, BYTE* buf);
 static int SCSIU_WriteBlocks(DWORD lba, DWORD count, DWORD blockSize, const BYTE* buf);
 static int SCSIU_EnsureBootCache(void);
 static int SCSIU_ReadCapacity(DWORD* outLastLBA, DWORD* outBlockSize);
+static void SCSIU_ResetBootCache(void);
+static void SCSIU_InvalidateBootCacheRange(DWORD lba, DWORD count, DWORD blockSize);
 #endif
 static BYTE* SCSI_ImgBuf(void);
 static long  SCSI_ImgSize(void);
@@ -511,6 +513,7 @@ SCSIU_StopBridge(void)
 	if (interruptFd >= 0) {
 		close(interruptFd);
 	}
+	SCSIU_ResetBootCache();
 #endif
 }
 
@@ -851,6 +854,43 @@ SCSIU_WriteBlocks(DWORD lba, DWORD count, DWORD blockSize, const BYTE* buf)
 #define SCSIU_READ_CHUNK_BLOCKS  128  /* max blocks per DREG-EX burst (~64KB) */
 static BYTE*  s_scsiu_boot_cache      = NULL;
 static long   s_scsiu_boot_cache_size = 0;
+
+static void
+SCSIU_ResetBootCache(void)
+{
+	if (s_scsiu_boot_cache != NULL) {
+		free(s_scsiu_boot_cache);
+		s_scsiu_boot_cache = NULL;
+	}
+	s_scsiu_boot_cache_size = 0;
+}
+
+static void
+SCSIU_InvalidateBootCacheRange(DWORD lba, DWORD count, DWORD blockSize)
+{
+	unsigned long long writeStart;
+	unsigned long long writeBytes;
+	unsigned long long cacheBytes;
+
+	if (s_scsiu_boot_cache == NULL || count == 0 || blockSize == 0) {
+		return;
+	}
+
+	writeStart = (unsigned long long)lba * (unsigned long long)blockSize;
+	writeBytes = (unsigned long long)count * (unsigned long long)blockSize;
+	cacheBytes = (unsigned long long)s_scsiu_boot_cache_size;
+
+	if (writeStart < cacheBytes && writeBytes > 0) {
+		char cacheLog[128];
+		snprintf(cacheLog, sizeof(cacheLog),
+		         "SCSIU_CACHE: invalidated by write lba=%u blocks=%u blockSize=%u",
+		         (unsigned int)lba,
+		         (unsigned int)count,
+		         (unsigned int)blockSize);
+		SCSI_LogText(cacheLog);
+		SCSIU_ResetBootCache();
+	}
+}
 
 /*
  * ブートキャッシュを物理 HDD から読み込む。
@@ -1255,6 +1295,7 @@ void SCSI_Init(void)
 	s_scsi_deferred_boot_pending = 0;
 	s_scsi_deferred_boot_addr = 0;
 	s_scsi_deferred_d5 = 0;
+	SCSIU_ResetBootCache();
 	SCSI_LogInit();
 	s_spc_access_log_count = 0;
 	SCSI_InvalidateTransferCache();
@@ -1275,6 +1316,7 @@ void SCSI_Init(void)
 // -----------------------------------------------------------------------
 void SCSI_Cleanup(void)
 {
+	SCSIU_ResetBootCache();
 }
 
 void SCSI_InvalidateTransferCache(void)
@@ -2680,6 +2722,7 @@ static void SCSI_HandleIOCS(BYTE cmd)
 				result = 0xFFFFFFFF;
 				break;
 			}
+			SCSIU_InvalidateBootCacheRange(lba, blocks, blockSize);
 			free(tmpWr);
 			snprintf(logLine, sizeof(logLine),
 			         "SCSIU_XFER_WRITE cmd=$%02X lba=%u blocks=%u blockSize=%u",
@@ -3251,6 +3294,38 @@ static void SCSI_HandleIOCS(BYTE cmd)
 				byteOff = lba * blockSize;
 				byteLen = blocks * blockSize;
 				if (xferLen < byteLen) byteLen = xferLen;
+#ifdef __APPLE__
+				if (X68000_GetStorageBusMode() == 2) {
+					BYTE* tmpW = NULL;
+					DWORD writeBlocks = 0;
+					if (byteLen == 0 || (byteLen % blockSize) != 0) {
+						result = (DWORD)0xFFFFFFFF;
+						s_spc_status_byte = 0x02;
+						break;
+					}
+					writeBlocks = byteLen / blockSize;
+					tmpW = (BYTE*)malloc(byteLen);
+					if (tmpW == NULL) {
+						result = (DWORD)0xFFFFFFFF;
+						s_spc_status_byte = 0x02;
+						break;
+					}
+					{
+						DWORD wi;
+						for (wi = 0; wi < byteLen; wi++) {
+							tmpW[wi] = Memory_ReadB(srcAddr + wi);
+						}
+					}
+					if (!SCSIU_WriteBlocks(lba, writeBlocks, blockSize, tmpW)) {
+						free(tmpW);
+						result = (DWORD)0xFFFFFFFF;
+						s_spc_status_byte = 0x02;
+						break;
+					}
+					SCSIU_InvalidateBootCacheRange(lba, writeBlocks, blockSize);
+					free(tmpW);
+				} else
+#endif
 				if (s_disk_image_buffer[4] &&
 				    byteOff + byteLen <= (DWORD)s_disk_image_buffer_size[4]) {
 					DWORD wi;
@@ -5308,6 +5383,7 @@ static void SCSI_HandleDeviceCommand(void)
 				SCSI_LogText("SCSI_DEV WRITE SCSIU failed");
 				break;
 			}
+			SCSIU_InvalidateBootCacheRange(physLBA, physBlks, secSize);
 			free(tmpBuf);
 			SCSI_SetReqStatus(reqpkt, 1, 0x00);
 			{

--- a/X68000 Shared/px68k/x68k/scsi.c
+++ b/X68000 Shared/px68k/x68k/scsi.c
@@ -15,10 +15,25 @@
 #include	"palette.h"
 #include	"tvram.h"
 #include	"../x11/keyboard.h"
+#include	<stdio.h>
+#include	<stdarg.h>
 #include	<stdlib.h>
 #include	<sys/stat.h>
 #include	<sys/types.h>
 #include	<string.h>
+#include	<limits.h>
+
+#ifdef __APPLE__
+#include	<unistd.h>
+#include	<fcntl.h>
+#include	<errno.h>
+#include	<pthread.h>
+#include	<sys/termios.h>
+#include	<IOKit/IOKitLib.h>
+#include	<IOKit/usb/IOUSBLib.h>
+#include	<IOKit/serial/IOSerialKeys.h>
+#include	<CoreFoundation/CoreFoundation.h>
+#endif
 
 #if defined(HAVE_C68K)
 #include	"../m68000/c68k/c68k.h"
@@ -44,6 +59,30 @@ static DWORD s_last_iocs_sig_a1 = 0;
 static int s_scsi_log_total = 0;        // global log line counter
 #define SCSI_LOG_LIMIT 50000             // stop logging after this many lines
 
+#ifdef __APPLE__
+#define SCSIU_VENDOR_ID  0x04d8
+#define SCSIU_PRODUCT_ID 0xE6B2
+#define SCSIU_MAX_PORTS  8
+#define SCSIU_PATH_LEN   256
+
+typedef struct {
+	int control_fd;
+	int interrupt_fd;
+	pthread_t interrupt_thread;
+	pthread_mutex_t mutex;
+	int connected;
+	int active;
+	unsigned int interrupt_count;
+	char control_path[SCSIU_PATH_LEN];
+	char interrupt_path[SCSIU_PATH_LEN];
+	char status[128];
+} SCSIU_BridgeState;
+
+static SCSIU_BridgeState s_scsi_u_bridge = {
+	-1, -1, 0, PTHREAD_MUTEX_INITIALIZER, 0, 0, 0, "", "", "Disconnected"
+};
+#endif
+
 // Runtime file logging is disabled by default — fopen/fprintf/fclose on every
 // IOCS trap and SPC register poll stalls the main thread. Enable with
 // -DMPX68K_ENABLE_RUNTIME_FILE_LOGS=1 only when debugging SCSI boot.
@@ -53,6 +92,19 @@ static int s_scsi_log_total = 0;        // global log line counter
 
 // Forward declarations
 void SCSI_LogText(const char* text);
+
+#ifdef __APPLE__
+static void SCSIU_SetStatusLocked(const char* fmt, ...);
+static int SCSIU_FindCandidatePorts(char paths[SCSIU_MAX_PORTS][SCSIU_PATH_LEN], int maxPorts);
+static int SCSIU_OpenPort(const char* path);
+static int SCSIU_ProbePortRole(int fd, char* outRole);
+static void* SCSIU_InterruptThread(void* arg);
+static BYTE SCSIU_ExecSPCReg(BYTE regAddr);
+static void SCSIU_SendSPCReg(BYTE regAddr, BYTE val);
+static int SCSIU_ExecDregBurst(BYTE* buf, DWORD maxLen);
+static int SCSIU_ReadBlocks(DWORD lba, DWORD count, DWORD blockSize, BYTE* buf);
+static int SCSIU_WriteBlocks(DWORD lba, DWORD count, DWORD blockSize, const BYTE* buf);
+#endif
 
 
 // Minimal SPC (MB89352) register state for driver initialization.
@@ -132,6 +184,660 @@ static DWORD SCSI_Mask24(DWORD addr);
 static void SCSI_NormalizeRootShortNames(DWORD bufAddr, DWORD startSec,
                                          DWORD count, DWORD secSize);
 static void SCSI_LogKernelQueueState(const char* tag);
+
+#ifdef __APPLE__
+static void
+SCSIU_SetStatusLocked(const char* fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	vsnprintf(s_scsi_u_bridge.status, sizeof(s_scsi_u_bridge.status), fmt, ap);
+	va_end(ap);
+}
+
+static int
+SCSIU_CopyDialinPath(io_object_t service, char* outPath, int outSize)
+{
+	CFTypeRef devicePathRef;
+	Boolean ok;
+
+	devicePathRef = IORegistryEntryCreateCFProperty(service, CFSTR(kIODialinDeviceKey), kCFAllocatorDefault, 0);
+	if (devicePathRef == NULL) {
+		return 0;
+	}
+	ok = CFGetTypeID(devicePathRef) == CFStringGetTypeID() &&
+	     CFStringGetCString((CFStringRef)devicePathRef, outPath, outSize, kCFStringEncodingUTF8);
+	CFRelease(devicePathRef);
+	return ok ? 1 : 0;
+}
+
+static int
+SCSIU_FindCandidatePorts(char paths[SCSIU_MAX_PORTS][SCSIU_PATH_LEN], int maxPorts)
+{
+	CFMutableDictionaryRef matchDict;
+	CFNumberRef vendorRef;
+	CFNumberRef productRef;
+	SInt32 vendorId;
+	SInt32 productId;
+	io_iterator_t iterator;
+	io_object_t usbDevice;
+	int count;
+
+	matchDict = IOServiceMatching(kIOUSBDeviceClassName);
+	if (matchDict == NULL) {
+		return 0;
+	}
+
+	vendorId = SCSIU_VENDOR_ID;
+	productId = SCSIU_PRODUCT_ID;
+	vendorRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &vendorId);
+	productRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &productId);
+	if (vendorRef == NULL || productRef == NULL) {
+		if (vendorRef != NULL) CFRelease(vendorRef);
+		if (productRef != NULL) CFRelease(productRef);
+		return 0;
+	}
+
+	CFDictionarySetValue(matchDict, CFSTR(kUSBVendorID), vendorRef);
+	CFDictionarySetValue(matchDict, CFSTR(kUSBProductID), productRef);
+	CFRelease(vendorRef);
+	CFRelease(productRef);
+
+	if (IOServiceGetMatchingServices(kIOMainPortDefault, matchDict, &iterator) != KERN_SUCCESS) {
+		return 0;
+	}
+
+	count = 0;
+	while ((usbDevice = IOIteratorNext(iterator)) != IO_OBJECT_NULL) {
+		io_iterator_t childIterator;
+		if (IORegistryEntryCreateIterator(usbDevice, kIOServicePlane, kIORegistryIterateRecursively, &childIterator) == KERN_SUCCESS) {
+			io_object_t childService;
+			while ((childService = IOIteratorNext(childIterator)) != IO_OBJECT_NULL) {
+				char devicePath[SCSIU_PATH_LEN];
+				int duplicate;
+				int i;
+
+				if (!SCSIU_CopyDialinPath(childService, devicePath, sizeof(devicePath))) {
+					IOObjectRelease(childService);
+					continue;
+				}
+
+				duplicate = 0;
+				for (i = 0; i < count; ++i) {
+					if (strncmp(paths[i], devicePath, SCSIU_PATH_LEN) == 0) {
+						duplicate = 1;
+						break;
+					}
+				}
+				if (!duplicate && count < maxPorts) {
+					strncpy(paths[count], devicePath, SCSIU_PATH_LEN - 1);
+					paths[count][SCSIU_PATH_LEN - 1] = '\0';
+					++count;
+				}
+				IOObjectRelease(childService);
+			}
+			IOObjectRelease(childIterator);
+		}
+		IOObjectRelease(usbDevice);
+	}
+
+	IOObjectRelease(iterator);
+	return count;
+}
+
+static int
+SCSIU_OpenPort(const char* path)
+{
+	int fd;
+	struct termios tty;
+
+	fd = open(path, O_RDWR | O_NOCTTY | O_NONBLOCK);
+	if (fd < 0) {
+		return -1;
+	}
+	if (tcgetattr(fd, &tty) < 0) {
+		close(fd);
+		return -1;
+	}
+
+	cfmakeraw(&tty);
+	cfsetispeed(&tty, B230400);
+	cfsetospeed(&tty, B230400);
+	tty.c_cflag &= ~PARENB;
+	tty.c_cflag &= ~CSTOPB;
+	tty.c_cflag &= ~CSIZE;
+	tty.c_cflag |= CS8;
+	tty.c_cflag |= CREAD | CLOCAL;
+	tty.c_cc[VMIN] = 0;
+	tty.c_cc[VTIME] = 0;
+
+	if (tcsetattr(fd, TCSANOW, &tty) < 0) {
+		close(fd);
+		return -1;
+	}
+
+	tcflush(fd, TCIOFLUSH);
+	return fd;
+}
+
+static int
+SCSIU_ProbePortRole(int fd, char* outRole)
+{
+	unsigned char request;
+	unsigned char response;
+	int i;
+
+	request = 0x00;
+	response = 0x00;
+	tcflush(fd, TCIOFLUSH);
+	if (write(fd, &request, 1) != 1) {
+		return 0;
+	}
+
+	for (i = 0; i < 50; ++i) {
+		ssize_t bytesRead = read(fd, &response, 1);
+		if (bytesRead == 1) {
+			if (response == 's' || response == 'S') {
+				*outRole = (char)response;
+				return 1;
+			}
+		} else if (bytesRead < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+			return 0;
+		}
+		usleep(10000);
+	}
+
+	return 0;
+}
+
+static void*
+SCSIU_InterruptThread(void* arg)
+{
+	(void)arg;
+	while (s_scsi_u_bridge.active) {
+		unsigned char data;
+		ssize_t bytesRead = read(s_scsi_u_bridge.interrupt_fd, &data, 1);
+		if (bytesRead == 1) {
+			if (data == 'I') {
+				pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+				s_scsi_u_bridge.interrupt_count += 1;
+				SCSIU_SetStatusLocked("Connected (%u IRQ)", s_scsi_u_bridge.interrupt_count);
+				pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+			}
+		} else if (bytesRead < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+			pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+			SCSIU_SetStatusLocked("Interrupt port read error");
+			pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+			break;
+		}
+		usleep(1000);
+	}
+	return NULL;
+}
+#endif
+
+int
+SCSIU_InitBridge(void)
+{
+#ifdef __APPLE__
+	char paths[SCSIU_MAX_PORTS][SCSIU_PATH_LEN];
+	int portCount;
+	int i;
+	int controlFd;
+	int interruptFd;
+
+	pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+	if (s_scsi_u_bridge.connected) {
+		SCSIU_SetStatusLocked("Connected");
+		pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+		return 1;
+	}
+	s_scsi_u_bridge.interrupt_count = 0;
+	SCSIU_SetStatusLocked("Searching for SCSI-U");
+	pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+
+	memset(paths, 0, sizeof(paths));
+	portCount = SCSIU_FindCandidatePorts(paths, SCSIU_MAX_PORTS);
+	if (portCount < 2) {
+		pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+		SCSIU_SetStatusLocked("SCSI-U serial ports not found");
+		pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+		return 0;
+	}
+
+	controlFd = -1;
+	interruptFd = -1;
+	for (i = 0; i < portCount; ++i) {
+		int fd;
+		char role;
+
+		fd = SCSIU_OpenPort(paths[i]);
+		if (fd < 0) {
+			continue;
+		}
+		role = '\0';
+		if (!SCSIU_ProbePortRole(fd, &role)) {
+			close(fd);
+			continue;
+		}
+		if (role == 's' && controlFd < 0) {
+			controlFd = fd;
+			pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+			strncpy(s_scsi_u_bridge.control_path, paths[i], sizeof(s_scsi_u_bridge.control_path) - 1);
+			s_scsi_u_bridge.control_path[sizeof(s_scsi_u_bridge.control_path) - 1] = '\0';
+			pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+			continue;
+		}
+		if (role == 'S' && interruptFd < 0) {
+			interruptFd = fd;
+			pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+			strncpy(s_scsi_u_bridge.interrupt_path, paths[i], sizeof(s_scsi_u_bridge.interrupt_path) - 1);
+			s_scsi_u_bridge.interrupt_path[sizeof(s_scsi_u_bridge.interrupt_path) - 1] = '\0';
+			pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+			continue;
+		}
+		close(fd);
+	}
+
+	if (controlFd < 0 || interruptFd < 0) {
+		if (controlFd >= 0) close(controlFd);
+		if (interruptFd >= 0) close(interruptFd);
+		pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+		s_scsi_u_bridge.control_path[0] = '\0';
+		s_scsi_u_bridge.interrupt_path[0] = '\0';
+		SCSIU_SetStatusLocked("Handshake failed");
+		pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+		return 0;
+	}
+
+	pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+	s_scsi_u_bridge.control_fd = controlFd;
+	s_scsi_u_bridge.interrupt_fd = interruptFd;
+	s_scsi_u_bridge.active = 1;
+	s_scsi_u_bridge.connected = 1;
+	SCSIU_SetStatusLocked("Connected");
+	pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+
+	if (pthread_create(&s_scsi_u_bridge.interrupt_thread, NULL, SCSIU_InterruptThread, NULL) != 0) {
+		SCSIU_StopBridge();
+		pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+		SCSIU_SetStatusLocked("Interrupt thread start failed");
+		pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+		return 0;
+	}
+
+	return 1;
+#else
+	return 0;
+#endif
+}
+
+void
+SCSIU_StopBridge(void)
+{
+#ifdef __APPLE__
+	int controlFd;
+	int interruptFd;
+	pthread_t thread;
+	int shouldJoin;
+
+	pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+	controlFd = s_scsi_u_bridge.control_fd;
+	interruptFd = s_scsi_u_bridge.interrupt_fd;
+	thread = s_scsi_u_bridge.interrupt_thread;
+	shouldJoin = (s_scsi_u_bridge.connected && thread != 0);
+	s_scsi_u_bridge.active = 0;
+	s_scsi_u_bridge.connected = 0;
+	s_scsi_u_bridge.control_fd = -1;
+	s_scsi_u_bridge.interrupt_fd = -1;
+	s_scsi_u_bridge.interrupt_thread = 0;
+	s_scsi_u_bridge.interrupt_count = 0;
+	s_scsi_u_bridge.control_path[0] = '\0';
+	s_scsi_u_bridge.interrupt_path[0] = '\0';
+	SCSIU_SetStatusLocked("Disconnected");
+	pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+
+	if (shouldJoin) {
+		pthread_join(thread, NULL);
+	}
+	if (controlFd >= 0) {
+		close(controlFd);
+	}
+	if (interruptFd >= 0) {
+		close(interruptFd);
+	}
+#endif
+}
+
+int
+SCSIU_IsConnected(void)
+{
+#ifdef __APPLE__
+	int connected;
+
+	pthread_mutex_lock(&s_scsi_u_bridge.mutex);
+	connected = s_scsi_u_bridge.connected;
+	pthread_mutex_unlock(&s_scsi_u_bridge.mutex);
+	return connected;
+#else
+	return 0;
+#endif
+}
+
+const char*
+SCSIU_GetStatus(void)
+{
+#ifdef __APPLE__
+	return s_scsi_u_bridge.status;
+#else
+	return "Unavailable on this platform";
+#endif
+}
+
+// ---------------------------------------------------------------------------------------
+//  SCSI-U SPC (MB89352) レジスタ操作 — USB serial 経由
+//  コントロールポートへのプロトコル:
+//    読出し: cmd バイトを送信 → 1バイト受信
+//    書込み: cmd|0x80 バイトを送信 → val バイトを送信
+//    DREG-EX (0x41): 0x41 を送信 → 2バイト length → length バイトのデータ
+// ---------------------------------------------------------------------------------------
+#ifdef __APPLE__
+
+/* SPC レジスタ読出し。タイムアウト時は 0xFF を返す。 */
+static BYTE
+SCSIU_ExecSPCReg(BYTE regAddr)
+{
+	unsigned char buf;
+	int i;
+
+	if (s_scsi_u_bridge.control_fd < 0) {
+		return 0xFF;
+	}
+	if (write(s_scsi_u_bridge.control_fd, &regAddr, 1) != 1) {
+		return 0xFF;
+	}
+	/* 200ms ポーリング (20000 × 10μs) */
+	for (i = 0; i < 20000; ++i) {
+		ssize_t n = read(s_scsi_u_bridge.control_fd, &buf, 1);
+		if (n == 1) {
+			return buf;
+		} else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+			return 0xFF;
+		}
+		usleep(10);
+	}
+	return 0xFF;
+}
+
+/* SPC レジスタ書込み。cmd|0x80, val の 2バイトを送信する。 */
+static void
+SCSIU_SendSPCReg(BYTE regAddr, BYTE val)
+{
+	unsigned char cmd[2];
+
+	if (s_scsi_u_bridge.control_fd < 0) {
+		return;
+	}
+	cmd[0] = (unsigned char)(regAddr | 0x80);
+	cmd[1] = val;
+	(void)write(s_scsi_u_bridge.control_fd, cmd, 2);
+}
+
+/*
+ * DREG-EX (0x41) による一括データ受信。
+ * spc_bridger の m_ExecEx() 相当。
+ * 戻り値: 受信バイト数 (≥0)、エラー時 -1。
+ */
+static int
+SCSIU_ExecDregBurst(BYTE* buf, DWORD maxLen)
+{
+	BYTE cmd = 0x41;
+	unsigned char lenBuf[2];
+	DWORD dataLen;
+	DWORD received;
+	int i;
+
+	if (s_scsi_u_bridge.control_fd < 0) {
+		return -1;
+	}
+	tcflush(s_scsi_u_bridge.control_fd, TCIOFLUSH);
+	if (write(s_scsi_u_bridge.control_fd, &cmd, 1) != 1) {
+		return -1;
+	}
+
+	/* 2バイトの length (little-endian) を受信 */
+	received = 0;
+	for (i = 0; i < 2000 && received < 2; ++i) {
+		ssize_t n = read(s_scsi_u_bridge.control_fd, lenBuf + received, 2 - received);
+		if (n > 0) {
+			received += (DWORD)n;
+		} else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+			return -1;
+		}
+		if (received < 2) {
+			usleep(1000);
+		}
+	}
+	if (received < 2) {
+		return -1; /* タイムアウト */
+	}
+
+	dataLen = (DWORD)lenBuf[0] | ((DWORD)lenBuf[1] << 8);
+	if (dataLen > maxLen) {
+		dataLen = maxLen;
+	}
+
+	/* データ本体を受信 */
+	received = 0;
+	for (i = 0; i < 100000 && received < dataLen; ++i) {
+		ssize_t n = read(s_scsi_u_bridge.control_fd, buf + received, dataLen - received);
+		if (n > 0) {
+			received += (DWORD)n;
+		} else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+			return -1;
+		}
+		if (received < dataLen) {
+			usleep(100);
+		}
+	}
+	return (int)received;
+}
+
+/*
+ * INTS レジスタをポーリングして指定ビットが立つまで待つ。
+ * timeoutUs: マイクロ秒単位のタイムアウト。
+ * 戻り値: 1=成功, 0=タイムアウト。
+ */
+static int
+SCSIU_WaitINTS(BYTE mask, int timeoutUs)
+{
+	int elapsed = 0;
+
+	while (elapsed < timeoutUs) {
+		BYTE ints = SCSIU_ExecSPCReg(0x09/*INTS*/);
+		if (ints & mask) {
+			return 1;
+		}
+		usleep(200);
+		elapsed += 200;
+		/* 1回の ExecSPCReg は USB ラウンドトリップ (~1ms) を含むため
+		 * 実際のタイムアウトは timeoutUs より長くなる場合がある */
+	}
+	return 0;
+}
+
+/*
+ * SPC (MB89352) で SCSI READ(10) を実行して count ブロックを buf に読み込む。
+ * lba: 論理ブロックアドレス, count: ブロック数, blockSize: ブロックサイズ(bytes)
+ * 戻り値: 1=成功, 0=失敗
+ */
+static int
+SCSIU_ReadBlocks(DWORD lba, DWORD count, DWORD blockSize, BYTE* buf)
+{
+	DWORD totalBytes;
+	BYTE cdb[10];
+	int received;
+
+	if (!s_scsi_u_bridge.connected || s_scsi_u_bridge.control_fd < 0) {
+		return 0;
+	}
+	if (count == 0 || blockSize == 0) {
+		return 0;
+	}
+	totalBytes = count * blockSize;
+
+	/* --- 1. SPC 初期化 --- */
+	SCSIU_SendSPCReg(0x03/*SCTL*/, 0x14); /* Arb enable + initiator mode */
+	SCSIU_SendSPCReg(0x01/*BDID*/, 0x40); /* Host ID = 6 */
+
+	/* --- 2. ARBITRATION --- */
+	SCSIU_SendSPCReg(0x11/*PCTL*/, 0x00);
+	SCSIU_SendSPCReg(0x17/*TEMP*/, 0x01); /* Target ID = 0 */
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x04); /* ARBITRATION コマンド */
+	/* 仲裁完了: INTS bit4 (RESEL) または短いウェイト */
+	usleep(2000);
+
+	/* --- 3. SELECTION --- */
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x28); /* SELECTION + ATN */
+	/* COMMAND フェーズ遷移待ち: INTS bit3 (CMD_COMP) */
+	if (!SCSIU_WaitINTS(0x08, 2000000)) {
+		return 0;
+	}
+
+	/* --- 4. COMMAND PHASE: READ(10) CDB 送信 --- */
+	cdb[0] = 0x28; /* READ(10) */
+	cdb[1] = 0x00;
+	cdb[2] = (BYTE)((lba >> 24) & 0xFF);
+	cdb[3] = (BYTE)((lba >> 16) & 0xFF);
+	cdb[4] = (BYTE)((lba >> 8) & 0xFF);
+	cdb[5] = (BYTE)(lba & 0xFF);
+	cdb[6] = 0x00;
+	cdb[7] = (BYTE)((count >> 8) & 0xFF);
+	cdb[8] = (BYTE)(count & 0xFF);
+	cdb[9] = 0x00;
+
+	SCSIU_SendSPCReg(0x11/*PCTL*/, 0x02); /* Command phase */
+	{
+		int k;
+		for (k = 0; k < 10; ++k) {
+			SCSIU_SendSPCReg(0x15/*DREG*/, cdb[k]);
+		}
+	}
+
+	/* --- 5. DATA IN フェーズ待ち --- */
+	if (!SCSIU_WaitINTS(0x08, 5000000)) {
+		return 0;
+	}
+
+	/* --- 6. TC 設定 + Initiator Receive --- */
+	SCSIU_SendSPCReg(0x19/*TCH*/, (BYTE)((totalBytes >> 16) & 0xFF));
+	SCSIU_SendSPCReg(0x1B/*TCM*/, (BYTE)((totalBytes >>  8) & 0xFF));
+	SCSIU_SendSPCReg(0x1D/*TCL*/, (BYTE)(totalBytes & 0xFF));
+	SCSIU_SendSPCReg(0x11/*PCTL*/, 0x01); /* Data In phase */
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x84); /* Initiator Receive */
+
+	/* --- 7. データ受信 (DREG-EX で一括) --- */
+	received = SCSIU_ExecDregBurst(buf, totalBytes);
+	if (received < 0 || (DWORD)received < totalBytes) {
+		return 0;
+	}
+
+	/* --- 8. STATUS + MESSAGE フェーズ (完了処理) --- */
+	SCSIU_WaitINTS(0x08, 2000000);
+	SCSIU_ExecSPCReg(0x15/*DREG*/); /* status byte */
+	SCSIU_WaitINTS(0x08, 1000000);
+	SCSIU_ExecSPCReg(0x15/*DREG*/); /* message byte */
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x28); /* Message Accept */
+
+	return 1;
+}
+
+/*
+ * SPC (MB89352) で SCSI WRITE(10) を実行して count ブロックを buf から書き込む。
+ * 戻り値: 1=成功, 0=失敗
+ */
+static int
+SCSIU_WriteBlocks(DWORD lba, DWORD count, DWORD blockSize, const BYTE* buf)
+{
+	DWORD totalBytes;
+	BYTE cdb[10];
+
+	if (!s_scsi_u_bridge.connected || s_scsi_u_bridge.control_fd < 0) {
+		return 0;
+	}
+	if (count == 0 || blockSize == 0) {
+		return 0;
+	}
+	totalBytes = count * blockSize;
+
+	/* --- 1. SPC 初期化 --- */
+	SCSIU_SendSPCReg(0x03/*SCTL*/, 0x14);
+	SCSIU_SendSPCReg(0x01/*BDID*/, 0x40);
+
+	/* --- 2. ARBITRATION --- */
+	SCSIU_SendSPCReg(0x11/*PCTL*/, 0x00);
+	SCSIU_SendSPCReg(0x17/*TEMP*/, 0x01);
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x04);
+	usleep(2000);
+
+	/* --- 3. SELECTION --- */
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x28);
+	if (!SCSIU_WaitINTS(0x08, 2000000)) {
+		return 0;
+	}
+
+	/* --- 4. COMMAND PHASE: WRITE(10) CDB 送信 --- */
+	cdb[0] = 0x2A; /* WRITE(10) */
+	cdb[1] = 0x00;
+	cdb[2] = (BYTE)((lba >> 24) & 0xFF);
+	cdb[3] = (BYTE)((lba >> 16) & 0xFF);
+	cdb[4] = (BYTE)((lba >> 8) & 0xFF);
+	cdb[5] = (BYTE)(lba & 0xFF);
+	cdb[6] = 0x00;
+	cdb[7] = (BYTE)((count >> 8) & 0xFF);
+	cdb[8] = (BYTE)(count & 0xFF);
+	cdb[9] = 0x00;
+
+	SCSIU_SendSPCReg(0x11/*PCTL*/, 0x02);
+	{
+		int k;
+		for (k = 0; k < 10; ++k) {
+			SCSIU_SendSPCReg(0x15/*DREG*/, cdb[k]);
+		}
+	}
+
+	/* --- 5. DATA OUT フェーズ待ち --- */
+	if (!SCSIU_WaitINTS(0x08, 5000000)) {
+		return 0;
+	}
+
+	/* --- 6. TC 設定 + Initiator Send --- */
+	SCSIU_SendSPCReg(0x19/*TCH*/, (BYTE)((totalBytes >> 16) & 0xFF));
+	SCSIU_SendSPCReg(0x1B/*TCM*/, (BYTE)((totalBytes >>  8) & 0xFF));
+	SCSIU_SendSPCReg(0x1D/*TCL*/, (BYTE)(totalBytes & 0xFF));
+	SCSIU_SendSPCReg(0x11/*PCTL*/, 0x00); /* Data Out phase */
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0xC4); /* Initiator Send */
+
+	/* --- 7. データ送信 (1バイトずつ DREG に書く) --- */
+	{
+		DWORD k;
+		for (k = 0; k < totalBytes; ++k) {
+			SCSIU_SendSPCReg(0x15/*DREG*/, buf[k]);
+		}
+	}
+
+	/* --- 8. STATUS + MESSAGE フェーズ --- */
+	SCSIU_WaitINTS(0x08, 2000000);
+	SCSIU_ExecSPCReg(0x15/*DREG*/); /* status byte */
+	SCSIU_WaitINTS(0x08, 1000000);
+	SCSIU_ExecSPCReg(0x15/*DREG*/); /* message byte */
+	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x28); /* Message Accept */
+
+	return 1;
+}
+
+#endif /* __APPLE__ */
 
 // ---------------------------------------------------------------------------------------
 //  合成SCSI ROM (外付けSCSI CZ-6BS1互換: $EA0000-$EA1FFF)
@@ -771,10 +1477,19 @@ static int SCSI_ResolveTransfer(DWORD lba, DWORD blocks, DWORD blockSize,
 	unsigned long long start;
 	unsigned long long bytes;
 
-	if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] <= 0) {
+	if (blocks == 0 || blockSize == 0) {
 		return 0;
 	}
-	if (blocks == 0 || blockSize == 0) {
+
+	/* SCSI-U モード: image buffer を使わず lba/blockSize から転送量を計算する */
+	if (X68000_GetStorageBusMode() == 2) {
+		*imageOffset = 0; /* 未使用 */
+		bytes = (unsigned long long)blocks * (unsigned long long)blockSize;
+		*transferBytes = (DWORD)bytes;
+		return 1;
+	}
+
+	if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] <= 0) {
 		return 0;
 	}
 
@@ -1610,9 +2325,30 @@ static void SCSI_HandleIOCS(BYTE cmd)
 			break;
 		}
 
-		for (i = 0; i < transferBytes; i++) {
-			Memory_WriteB(a1 + i, s_disk_image_buffer[4][imageOffset + i]);
-		}
+		if (X68000_GetStorageBusMode() == 2) {
+#ifdef __APPLE__
+			BYTE* tmpRd = (BYTE*)malloc(transferBytes);
+			if (tmpRd == NULL || !SCSIU_ReadBlocks(lba, blocks, blockSize, tmpRd)) {
+				free(tmpRd);
+				result = 0xFFFFFFFF;
+				break;
+			}
+			for (i = 0; i < transferBytes; i++) {
+				Memory_WriteB(a1 + i, tmpRd[i]);
+			}
+			free(tmpRd);
+			snprintf(logLine, sizeof(logLine),
+			         "SCSIU_XFER_READ cmd=$%02X lba=%u blocks=%u blockSize=%u",
+			         cmd, (unsigned int)lba, (unsigned int)blocks, (unsigned int)blockSize);
+			SCSI_LogText(logLine);
+#else
+			result = 0xFFFFFFFF;
+			break;
+#endif
+		} else {
+			for (i = 0; i < transferBytes; i++) {
+				Memory_WriteB(a1 + i, s_disk_image_buffer[4][imageOffset + i]);
+			}
 			snprintf(logLine, sizeof(logLine),
 			         "SCSI_XFER_READ cmd=$%02X lba=%u blocks=%u blockSize=%u imgOff=0x%X first=%02X%02X%02X%02X",
 			         cmd,
@@ -1620,11 +2356,12 @@ static void SCSI_HandleIOCS(BYTE cmd)
 			         (unsigned int)blocks,
 			         (unsigned int)blockSize,
 			         (unsigned int)imageOffset,
-		         s_disk_image_buffer[4][imageOffset + 0],
-		         s_disk_image_buffer[4][imageOffset + 1],
-		         s_disk_image_buffer[4][imageOffset + 2],
-		         s_disk_image_buffer[4][imageOffset + 3]);
-		SCSI_LogText(logLine);
+			         s_disk_image_buffer[4][imageOffset + 0],
+			         s_disk_image_buffer[4][imageOffset + 1],
+			         s_disk_image_buffer[4][imageOffset + 2],
+			         s_disk_image_buffer[4][imageOffset + 3]);
+			SCSI_LogText(logLine);
+		}
 		result = 0;
 		break;
 	}
@@ -1738,9 +2475,34 @@ static void SCSI_HandleIOCS(BYTE cmd)
 			break;
 		}
 
-		for (i = 0; i < transferBytes; i++) {
-			s_disk_image_buffer[4][imageOffset + i] = Memory_ReadB(a1 + i);
-		}
+		if (X68000_GetStorageBusMode() == 2) {
+#ifdef __APPLE__
+			BYTE* tmpWr = (BYTE*)malloc(transferBytes);
+			if (tmpWr == NULL) {
+				result = 0xFFFFFFFF;
+				break;
+			}
+			for (i = 0; i < transferBytes; i++) {
+				tmpWr[i] = Memory_ReadB(a1 + i);
+			}
+			if (!SCSIU_WriteBlocks(lba, blocks, blockSize, tmpWr)) {
+				free(tmpWr);
+				result = 0xFFFFFFFF;
+				break;
+			}
+			free(tmpWr);
+			snprintf(logLine, sizeof(logLine),
+			         "SCSIU_XFER_WRITE cmd=$%02X lba=%u blocks=%u blockSize=%u",
+			         cmd, (unsigned int)lba, (unsigned int)blocks, (unsigned int)blockSize);
+			SCSI_LogText(logLine);
+#else
+			result = 0xFFFFFFFF;
+			break;
+#endif
+		} else {
+			for (i = 0; i < transferBytes; i++) {
+				s_disk_image_buffer[4][imageOffset + i] = Memory_ReadB(a1 + i);
+			}
 			snprintf(logLine, sizeof(logLine),
 			         "SCSI_XFER_WRITE cmd=$%02X lba=%u blocks=%u blockSize=%u imgOff=0x%X",
 			         cmd,
@@ -1748,7 +2510,8 @@ static void SCSI_HandleIOCS(BYTE cmd)
 			         (unsigned int)blocks,
 			         (unsigned int)blockSize,
 			         (unsigned int)imageOffset);
-		SCSI_LogText(logLine);
+			SCSI_LogText(logLine);
+		}
 		SASI_SetDirtyFlag(0);
 		result = 0;
 		break;
@@ -1787,6 +2550,29 @@ static void SCSI_HandleIOCS(BYTE cmd)
 		if (!SCSI_IsLinearRamRange(a1, transferBytes)) {
 			result = 0xFFFFFFFF;
 			break;
+		}
+		if (X68000_GetStorageBusMode() == 2) {
+#ifdef __APPLE__
+			BYTE* tmpRd2 = (BYTE*)malloc(transferBytes);
+			if (tmpRd2 == NULL || !SCSIU_ReadBlocks(lba, blocks, blockSize, tmpRd2)) {
+				free(tmpRd2);
+				result = 0xFFFFFFFF;
+				break;
+			}
+			for (i = 0; i < transferBytes; i++) {
+				Memory_WriteB(a1 + i, tmpRd2[i]);
+			}
+			free(tmpRd2);
+			snprintf(logLine, sizeof(logLine),
+			         "SCSIU_XFER_READ cmd=$%02X lba=%u blocks=%u blockSize=%u",
+			         cmd, (unsigned int)lba, (unsigned int)blocks, (unsigned int)blockSize);
+			SCSI_LogText(logLine);
+			result = 0;
+			break;
+#else
+			result = 0xFFFFFFFF;
+			break;
+#endif
 		}
 		for (i = 0; i < transferBytes; i++) {
 			Memory_WriteB(a1 + i, s_disk_image_buffer[4][imageOffset + i]);
@@ -1832,15 +2618,51 @@ static void SCSI_HandleIOCS(BYTE cmd)
 		break;
 
 	case 0x24:  // _S_TESTUNIT
-		result = (s_disk_image_buffer[4] != NULL && s_disk_image_buffer_size[4] > 0) ? 0 : 0xFFFFFFFF;
+		if (X68000_GetStorageBusMode() == 2) {
+			result = SCSIU_IsConnected() ? 0 : 0xFFFFFFFF;
+		} else {
+			result = (s_disk_image_buffer[4] != NULL && s_disk_image_buffer_size[4] > 0) ? 0 : 0xFFFFFFFF;
+		}
 		break;
 
 	case 0x25: {  // _S_READCAP
 		DWORD blockSize = SCSI_GetImageBlockSize();
-		DWORD dataOffset = SCSI_GetIocsDataOffset();
+		DWORD dataOffset;
 		DWORD dataSize = 0;
 		DWORD totalBlocks;
 
+		if (X68000_GetStorageBusMode() == 2) {
+			/* SCSI-U モード: SPC READ CAPACITY(10) で実際の値を取得する。
+			 * 暫定実装: デバイス接続確認のみ行い、固定 blockSize / 容量を返す。
+			 * TODO: SPC READ CAPACITY コマンドで実際の値を取得する。 */
+			if (!SCSIU_IsConnected()) {
+				result = 0xFFFFFFFF;
+				break;
+			}
+			if (!SCSI_IsLinearRamRange(a1, 8)) {
+				result = 0xFFFFFFFF;
+				break;
+			}
+			/* ブロックサイズは 512 バイト固定、容量は 4GB - 1 ブロック */
+			blockSize = 512;
+			totalBlocks = 0x800000; /* 4GB / 512 = 8388608 ブロック */
+			Memory_WriteB(a1 + 0, (BYTE)(((totalBlocks - 1) >> 24) & 0xff));
+			Memory_WriteB(a1 + 1, (BYTE)(((totalBlocks - 1) >> 16) & 0xff));
+			Memory_WriteB(a1 + 2, (BYTE)(((totalBlocks - 1) >>  8) & 0xff));
+			Memory_WriteB(a1 + 3, (BYTE)((totalBlocks - 1) & 0xff));
+			Memory_WriteB(a1 + 4, (BYTE)((blockSize >> 24) & 0xff));
+			Memory_WriteB(a1 + 5, (BYTE)((blockSize >> 16) & 0xff));
+			Memory_WriteB(a1 + 6, (BYTE)((blockSize >>  8) & 0xff));
+			Memory_WriteB(a1 + 7, (BYTE)(blockSize & 0xff));
+			snprintf(logLine, sizeof(logLine),
+			         "SCSIU_READCAP blocks=%u blockSize=%u (stub)",
+			         (unsigned int)totalBlocks, (unsigned int)blockSize);
+			SCSI_LogText(logLine);
+			result = 0;
+			break;
+		}
+
+		dataOffset = SCSI_GetIocsDataOffset();
 		if (s_disk_image_buffer[4] == NULL || s_disk_image_buffer_size[4] <= 0) {
 			result = 0xFFFFFFFF;
 			break;

--- a/X68000 Shared/px68k/x68k/scsi.c
+++ b/X68000 Shared/px68k/x68k/scsi.c
@@ -3216,27 +3216,32 @@ static void SCSI_HandleIOCS(BYTE cmd)
 				if (blocks == 0) blocks = 256;
 				DWORD blockSize = (X68000_GetStorageBusMode() == 2) ? SCSIU_GetBlockSize() : 512;
 				DWORD byteOff = lba * blockSize;
-				DWORD byteLen = blocks * blockSize;
+				DWORD fullByteLen = blocks * blockSize;
+				DWORD copyLen = fullByteLen;
 				DWORD ri;
-				if (xferLen < byteLen) byteLen = xferLen;
+				if (xferLen < copyLen) copyLen = xferLen;
 #ifdef __APPLE__
 				if (X68000_GetStorageBusMode() == 2) {
-					BYTE* tmpR6 = (BYTE*)malloc(byteLen);
-					if (tmpR6 && SCSIU_ReadBlocks(lba, byteLen / blockSize, blockSize, tmpR6)) {
-						for (ri = 0; ri < byteLen; ri++)
+					BYTE* tmpR6 = (BYTE*)malloc(fullByteLen);
+					if (tmpR6 && SCSIU_ReadBlocks(lba, blocks, blockSize, tmpR6)) {
+						for (ri = 0; ri < copyLen; ri++)
 							Memory_WriteB(dstAddr + ri, tmpR6[ri]);
 					} else {
-						for (ri = 0; ri < byteLen; ri++) Memory_WriteB(dstAddr + ri, 0x00);
+						s_spc_status_byte = 0x02;
+						result = (DWORD)0xFFFFFFFF;
 					}
 					free(tmpR6);
+					if (result != 0) {
+						break;
+					}
 				} else
 #endif
 				if (s_disk_image_buffer[4] &&
-				    byteOff + byteLen <= (DWORD)s_disk_image_buffer_size[4]) {
-					for (ri = 0; ri < byteLen; ri++)
+				    byteOff + copyLen <= (DWORD)s_disk_image_buffer_size[4]) {
+					for (ri = 0; ri < copyLen; ri++)
 						Memory_WriteB(dstAddr + ri, s_disk_image_buffer[4][byteOff + ri]);
 				} else {
-					for (ri = 0; ri < byteLen; ri++)
+					for (ri = 0; ri < copyLen; ri++)
 						Memory_WriteB(dstAddr + ri, 0x00);
 				}
 				break;
@@ -3249,27 +3254,32 @@ static void SCSI_HandleIOCS(BYTE cmd)
 				DWORD blocks = ((DWORD)s_spc_cdb[7] << 8) | s_spc_cdb[8];
 				DWORD blockSize = (X68000_GetStorageBusMode() == 2) ? SCSIU_GetBlockSize() : 512;
 				DWORD byteOff = lba * blockSize;
-				DWORD byteLen = blocks * blockSize;
+				DWORD fullByteLen = blocks * blockSize;
+				DWORD copyLen = fullByteLen;
 				DWORD ri;
-				if (xferLen < byteLen) byteLen = xferLen;
+				if (xferLen < copyLen) copyLen = xferLen;
 #ifdef __APPLE__
 				if (X68000_GetStorageBusMode() == 2) {
-					BYTE* tmpR10 = (BYTE*)malloc(byteLen);
+					BYTE* tmpR10 = (BYTE*)malloc(fullByteLen);
 					if (tmpR10 && blocks > 0 && SCSIU_ReadBlocks(lba, blocks, blockSize, tmpR10)) {
-						for (ri = 0; ri < byteLen; ri++)
+						for (ri = 0; ri < copyLen; ri++)
 							Memory_WriteB(dstAddr + ri, tmpR10[ri]);
 					} else {
-						for (ri = 0; ri < byteLen; ri++) Memory_WriteB(dstAddr + ri, 0x00);
+						s_spc_status_byte = 0x02;
+						result = (DWORD)0xFFFFFFFF;
 					}
 					free(tmpR10);
+					if (result != 0) {
+						break;
+					}
 				} else
 #endif
 				if (s_disk_image_buffer[4] &&
-				    byteOff + byteLen <= (DWORD)s_disk_image_buffer_size[4]) {
-					for (ri = 0; ri < byteLen; ri++)
+				    byteOff + copyLen <= (DWORD)s_disk_image_buffer_size[4]) {
+					for (ri = 0; ri < copyLen; ri++)
 						Memory_WriteB(dstAddr + ri, s_disk_image_buffer[4][byteOff + ri]);
 				} else {
-					for (ri = 0; ri < byteLen; ri++)
+					for (ri = 0; ri < copyLen; ri++)
 						Memory_WriteB(dstAddr + ri, 0x00);
 				}
 				break;

--- a/X68000 Shared/px68k/x68k/scsi.c
+++ b/X68000 Shared/px68k/x68k/scsi.c
@@ -64,6 +64,7 @@ static int s_scsi_log_total = 0;        // global log line counter
 #define SCSIU_PRODUCT_ID 0xE6B2
 #define SCSIU_MAX_PORTS  8
 #define SCSIU_PATH_LEN   256
+#define SCSIU_MAX_DREG_BURST_BYTES 0xFFFFu
 
 typedef struct {
 	int control_fd;
@@ -106,6 +107,7 @@ static int SCSIU_ReadBlocks(DWORD lba, DWORD count, DWORD blockSize, BYTE* buf);
 static int SCSIU_WriteBlocks(DWORD lba, DWORD count, DWORD blockSize, const BYTE* buf);
 static int SCSIU_EnsureBootCache(void);
 static int SCSIU_ReadCapacity(DWORD* outLastLBA, DWORD* outBlockSize);
+static int SCSIU_GetCapacity(DWORD* outTotalBlocks, DWORD* outBlockSize);
 static void SCSIU_ResetBootCache(void);
 static void SCSIU_InvalidateBootCacheRange(DWORD lba, DWORD count, DWORD blockSize);
 static DWORD SCSIU_GetBlockSize(void);
@@ -684,6 +686,8 @@ static int
 SCSIU_ReadBlocks(DWORD lba, DWORD count, DWORD blockSize, BYTE* buf)
 {
 	DWORD totalBytes;
+	DWORD remainingBytes;
+	BYTE* readPtr;
 	BYTE cdb[10];
 	int received;
 
@@ -745,10 +749,19 @@ SCSIU_ReadBlocks(DWORD lba, DWORD count, DWORD blockSize, BYTE* buf)
 	SCSIU_SendSPCReg(0x11/*PCTL*/, 0x01); /* Data In phase */
 	SCSIU_SendSPCReg(0x05/*SCMD*/, 0x84); /* Initiator Receive */
 
-	/* --- 7. データ受信 (DREG-EX で一括) --- */
-	received = SCSIU_ExecDregBurst(buf, totalBytes);
-	if (received < 0 || (DWORD)received < totalBytes) {
-		return 0;
+	/* --- 7. データ受信 (DREG-EX を 64KB 以下に分割) --- */
+	remainingBytes = totalBytes;
+	readPtr = buf;
+	while (remainingBytes > 0) {
+		DWORD chunkBytes = (remainingBytes > SCSIU_MAX_DREG_BURST_BYTES)
+		                 ? SCSIU_MAX_DREG_BURST_BYTES
+		                 : remainingBytes;
+		received = SCSIU_ExecDregBurst(readPtr, chunkBytes);
+		if (received < 0 || (DWORD)received < chunkBytes) {
+			return 0;
+		}
+		readPtr += chunkBytes;
+		remainingBytes -= chunkBytes;
 	}
 
 	/* --- 8. STATUS + MESSAGE フェーズ (完了処理) --- */
@@ -854,6 +867,7 @@ SCSIU_WriteBlocks(DWORD lba, DWORD count, DWORD blockSize, const BYTE* buf)
 #define SCSIU_BOOT_CACHE_TARGET_BYTES (4 * 1024 * 1024)
 static BYTE*  s_scsiu_boot_cache      = NULL;
 static long   s_scsiu_boot_cache_size = 0;
+static DWORD  s_scsiu_reported_total_blocks = 0;
 static DWORD  s_scsiu_reported_block_size = 512;
 static int    s_scsiu_capacity_valid = 0;
 
@@ -865,6 +879,7 @@ SCSIU_ResetBootCache(void)
 		s_scsiu_boot_cache = NULL;
 	}
 	s_scsiu_boot_cache_size = 0;
+	s_scsiu_reported_total_blocks = 0;
 	s_scsiu_reported_block_size = 512;
 	s_scsiu_capacity_valid = 0;
 }
@@ -896,16 +911,37 @@ SCSIU_InvalidateBootCacheRange(DWORD lba, DWORD count, DWORD blockSize)
 	}
 }
 
-static DWORD
-SCSIU_GetBlockSize(void)
+static int
+SCSIU_GetCapacity(DWORD* outTotalBlocks, DWORD* outBlockSize)
 {
 	DWORD lastLBA = 0;
 	DWORD blockSize = 0;
 
-	if (s_scsiu_capacity_valid && s_scsiu_reported_block_size != 0) {
-		return s_scsiu_reported_block_size;
+	if (outTotalBlocks == NULL || outBlockSize == NULL) {
+		return 0;
 	}
-	if (s_scsi_u_bridge.connected && SCSIU_ReadCapacity(&lastLBA, &blockSize) && blockSize != 0) {
+	if (s_scsiu_capacity_valid &&
+	    s_scsiu_reported_total_blocks != 0 &&
+	    s_scsiu_reported_block_size != 0) {
+		*outTotalBlocks = s_scsiu_reported_total_blocks;
+		*outBlockSize = s_scsiu_reported_block_size;
+		return 1;
+	}
+	if (!s_scsi_u_bridge.connected || !SCSIU_ReadCapacity(&lastLBA, &blockSize) || blockSize == 0) {
+		return 0;
+	}
+	*outTotalBlocks = s_scsiu_reported_total_blocks;
+	*outBlockSize = s_scsiu_reported_block_size;
+	return (*outTotalBlocks != 0 && *outBlockSize != 0) ? 1 : 0;
+}
+
+static DWORD
+SCSIU_GetBlockSize(void)
+{
+	DWORD totalBlocks = 0;
+	DWORD blockSize = 0;
+
+	if (SCSIU_GetCapacity(&totalBlocks, &blockSize) && blockSize != 0) {
 		return blockSize;
 	}
 	return (s_scsiu_reported_block_size != 0) ? s_scsiu_reported_block_size : 512;
@@ -921,6 +957,8 @@ static int
 SCSIU_EnsureBootCache(void)
 {
 	DWORD blockSize;
+	DWORD reportedBlocks = 0;
+	DWORD reportedBlockSize = 0;
 	DWORD totalBlocks;
 	DWORD totalBytes;
 	DWORD chunksRead  = 0;
@@ -937,12 +975,26 @@ SCSIU_EnsureBootCache(void)
 	if (blockSize == 0) {
 		blockSize = 512;
 	}
+	if (!SCSIU_GetCapacity(&reportedBlocks, &reportedBlockSize)) {
+		SCSI_LogText("SCSIU_CACHE: READ CAPACITY failed");
+		return 0;
+	}
+	if (reportedBlockSize != 0) {
+		blockSize = reportedBlockSize;
+	}
+	if (reportedBlocks == 0) {
+		SCSI_LogText("SCSIU_CACHE: zero-capacity device");
+		return 0;
+	}
 	totalBlocks = (DWORD)(((unsigned long long)SCSIU_BOOT_CACHE_TARGET_BYTES + blockSize - 1) / blockSize);
 	if (totalBlocks == 0) {
 		totalBlocks = 1;
 	}
+	if (totalBlocks > reportedBlocks) {
+		totalBlocks = reportedBlocks;
+	}
 	totalBytes = totalBlocks * blockSize;
-	chunkBlocks = 0xFFFFu / blockSize;
+	chunkBlocks = SCSIU_MAX_DREG_BURST_BYTES / blockSize;
 	if (chunkBlocks == 0) {
 		chunkBlocks = 1;
 	}
@@ -1047,6 +1099,9 @@ SCSIU_ReadCapacity(DWORD* outLastLBA, DWORD* outBlockSize)
 	                ((DWORD)resp[2] <<  8) |  (DWORD)resp[3];
 	*outBlockSize = ((DWORD)resp[4] << 24) | ((DWORD)resp[5] << 16) |
 	                ((DWORD)resp[6] <<  8) |  (DWORD)resp[7];
+	s_scsiu_reported_total_blocks = (*outLastLBA == 0xFFFFFFFFU)
+	                              ? 0xFFFFFFFFU
+	                              : (*outLastLBA + 1);
 	s_scsiu_reported_block_size = (*outBlockSize != 0) ? *outBlockSize : 512;
 	s_scsiu_capacity_valid = 1;
 	return 1;
@@ -4963,8 +5018,10 @@ static void SCSI_HandleDeviceCommand(void)
 					for (i = 0; i < (DWORD)byteCount; i++)
 						Memory_WriteB(bufAddr + i, tmpBuf[i]);
 				} else {
-					for (i = 0; i < (DWORD)byteCount; i++)
-						Memory_WriteB(bufAddr + i, 0x00);
+					free(tmpBuf);
+					SCSI_SetReqStatus(reqpkt, 0, 0x02);
+					SCSI_LogText("SCSI_DEV READ SCSIU failed");
+					break;
 				}
 				free(tmpBuf);
 				SCSI_SetReqStatus(reqpkt, 1, 0x00);

--- a/X68000 Shared/px68k/x68k/scsi.h
+++ b/X68000 Shared/px68k/x68k/scsi.h
@@ -28,6 +28,10 @@ int SCSI_IsROMPresent(void);
 void SCSI_Init(void);
 void SCSI_Cleanup(void);
 void SCSI_InvalidateTransferCache(void);
+int SCSIU_InitBridge(void);
+void SCSIU_StopBridge(void);
+int SCSIU_IsConnected(void);
+const char* SCSIU_GetStatus(void);
 
 BYTE FASTCALL SCSI_Read(DWORD adr);
 void FASTCALL SCSI_Write(DWORD adr, BYTE data);

--- a/X68000 macOS/AppDelegate.swift
+++ b/X68000 macOS/AppDelegate.swift
@@ -2389,6 +2389,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
         guard coreGetSCSIUState().connected else { return }
 
         coreDisconnectSCSIU()
+        UserDefaults.standard.storageBusMode = .sasi
+        cachedStorageBusMode = StorageBusMode.sasi.rawValue
+        DiskStateManager.shared.saveCurrentState()
         updateMenuTitles()
     }
 

--- a/X68000 macOS/AppDelegate.swift
+++ b/X68000 macOS/AppDelegate.swift
@@ -11,10 +11,11 @@ import UniformTypeIdentifiers
 import os.log
 import SwiftUI
 
-// Storage bus selection (SASI or SCSI). Default is SASI.
+// Storage bus selection. Default is SASI.
 enum StorageBusMode: Int {
     case sasi = 0
     case scsi = 1
+    case scsiU = 2
 }
 
 extension UserDefaults {
@@ -68,7 +69,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
     private let sccCompatCheckInterval: TimeInterval = 1.0
 
     // Storage bus / SCSI ID0 cached state
-    private var cachedStorageBusMode: Int = 0 // 0=SASI,1=SCSI
+    private var cachedStorageBusMode: Int = 0 // 0=SASI,1=SCSI image,2=SCSI-U
     private var cachedSCSIReady0: Bool = false
     private var cachedSCSIFilename0: String? = nil
     private var storageRestoreRetryCount: Int = 0
@@ -144,17 +145,44 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
 
     private func coreGetStorageBusMode() -> StorageBusMode {
         let mode = X68000_GetStorageBusMode()
-        return mode == 1 ? .scsi : .sasi
+        switch mode {
+        case 1:
+            return .scsi
+        case 2:
+            return .scsiU
+        default:
+            return .sasi
+        }
     }
 
     private func coreSetStorageBusMode(_ mode: StorageBusMode) {
-        X68000_SetStorageBusMode(mode == .scsi ? 1 : 0)
+        X68000_SetStorageBusMode(Int32(mode.rawValue))
     }
 
     private func coreGetSCSI0State() -> (ready: Bool, path: String?) {
         // If core exposes query APIs, prefer them; otherwise fall back to our cached values
         // Here we reuse our cache variables if core query is not available
         return (X68000_SCSI_IsMounted(0, 0) != 0, X68000_SCSI_GetImagePath(0, 0).flatMap { String(cString: $0) })
+    }
+
+    private func coreGetSCSIUState() -> (connected: Bool, status: String) {
+        let connected = X68000_SCSIU_IsConnected() != 0
+        let status = X68000_SCSIU_GetStatus().flatMap { String(cString: $0) } ?? "Unknown"
+        return (connected, status)
+    }
+
+    private func coreConnectSCSIU() -> Bool {
+        X68000_SCSIU_Connect() != 0
+    }
+
+    private func coreDisconnectSCSIU() {
+        X68000_SCSIU_Disconnect()
+    }
+
+    private func clearPersistedSCSI0State() {
+        let defaults = UserDefaults.standard
+        defaults.scsi0Ready = false
+        defaults.scsi0Filename = nil
     }
 
     private func coreMountSCSI0(path: String) -> Bool {
@@ -370,6 +398,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
         let alert = NSAlert()
         alert.messageText = "SCSI イメージをマウントできませんでした"
         alert.informativeText = "\(url.lastPathComponent)\n\(reason)"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        if let window = gameViewController?.view.window ?? NSApplication.shared.mainWindow {
+            alert.beginSheetModal(for: window, completionHandler: nil)
+        } else {
+            alert.runModal()
+        }
+    }
+
+    private func showSCSIUConnectionFailureAlert() {
+        let alert = NSAlert()
+        alert.messageText = "SCSI-U に接続できませんでした"
+        alert.informativeText = coreGetSCSIUState().status
         alert.alertStyle = .warning
         alert.addButton(withTitle: "OK")
         if let window = gameViewController?.view.window ?? NSApplication.shared.mainWindow {
@@ -646,6 +687,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
         busSCSI.identifier = NSUserInterfaceItemIdentifier("HDD-bus-SCSI")
         busMenu.addItem(busSCSI)
 
+        let busSCSIU = NSMenuItem(title: "SCSI-U", action: #selector(setStorageBusSCSIU(_:)), keyEquivalent: "")
+        busSCSIU.target = self
+        busSCSIU.identifier = NSUserInterfaceItemIdentifier("HDD-bus-SCSIU")
+        busMenu.addItem(busSCSIU)
+
         hddMenu.addItem(busMenuItem)
 
         // SCSI Devices submenu (ID 0 only for now).
@@ -669,6 +715,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
         scsiDevicesMenu.addItem(scsiEject0)
 
         hddMenu.addItem(scsiDevicesMenuItem)
+
+        let scsiUDevicesMenuItem = NSMenuItem(title: "SCSI-U Device", action: nil, keyEquivalent: "")
+        scsiUDevicesMenuItem.identifier = NSUserInterfaceItemIdentifier("SCSIU-device")
+        let scsiUDevicesMenu = NSMenu(title: "SCSI-U Device")
+        scsiUDevicesMenuItem.submenu = scsiUDevicesMenu
+
+        let scsiUStatus = NSMenuItem(title: "Status: Disconnected", action: nil, keyEquivalent: "")
+        scsiUStatus.identifier = NSUserInterfaceItemIdentifier("SCSIU-status")
+        scsiUStatus.isEnabled = false
+        scsiUDevicesMenu.addItem(scsiUStatus)
+
+        let scsiUConnect = NSMenuItem(title: "Connect SCSI-U", action: #selector(connectSCSIU(_:)), keyEquivalent: "")
+        scsiUConnect.target = self
+        scsiUConnect.identifier = NSUserInterfaceItemIdentifier("SCSIU-connect")
+        scsiUDevicesMenu.addItem(scsiUConnect)
+
+        let scsiUDisconnect = NSMenuItem(title: "Disconnect SCSI-U", action: #selector(disconnectSCSIU(_:)), keyEquivalent: "")
+        scsiUDisconnect.target = self
+        scsiUDisconnect.identifier = NSUserInterfaceItemIdentifier("SCSIU-disconnect")
+        scsiUDevicesMenu.addItem(scsiUDisconnect)
+
+        hddMenu.addItem(scsiUDevicesMenuItem)
 
         mainMenu.addItem(hddMenuItem)
 
@@ -1717,6 +1785,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
                     logger.debug("Updating HDD menu")
                     self.updateHDDMenuTitles(submenu: submenu)
                     self.updateSCSIMenuTitles(hddSubmenu: submenu)
+                    self.updateSCSIUMenuTitles(hddSubmenu: submenu)
                 } else if menuItem.title == "Display" {
                     logger.debug("Updating Display menu - skipping mouse checkmark update to prevent infinite loop")
                     // Commented out to prevent infinite loop:
@@ -1769,6 +1838,33 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
                     item.title = "Eject SCSI (ID 0)"
                     item.isEnabled = false
                 }
+            }
+        }
+    }
+
+    private func updateSCSIUMenuTitles(hddSubmenu: NSMenu) {
+        guard let scsiUDevicesItem = hddSubmenu.items.first(where: { $0.submenu?.title == "SCSI-U Device" }) else { return }
+        guard let scsiUSub = scsiUDevicesItem.submenu else { return }
+
+        let busMode = coreGetStorageBusMode()
+        let scsiU = coreGetSCSIUState()
+
+        scsiUDevicesItem.isEnabled = (busMode == .scsiU)
+
+        for item in scsiUSub.items {
+            let itemId = item.identifier?.rawValue ?? ""
+            switch itemId {
+            case "SCSIU-status":
+                item.title = "Status: \(scsiU.status)"
+                item.isEnabled = false
+            case "SCSIU-connect":
+                item.title = scsiU.connected ? "Reconnect SCSI-U" : "Connect SCSI-U"
+                item.isEnabled = (busMode == .scsiU && !scsiU.connected)
+            case "SCSIU-disconnect":
+                item.title = "Disconnect SCSI-U"
+                item.isEnabled = (busMode == .scsiU && scsiU.connected)
+            default:
+                break
             }
         }
     }
@@ -2139,8 +2235,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
     @objc func setStorageBusSASI(_ sender: Any?) {
         guard coreGetStorageBusMode() != .sasi else { return }
 
-        // If SCSI(ID0) is mounted, confirm unmount
-        if coreGetSCSI0State().ready {
+        let currentMode = coreGetStorageBusMode()
+
+        if currentMode == .scsiU && coreGetSCSIUState().connected {
+            let alert = NSAlert()
+            alert.messageText = "Switch to SASI Mode?"
+            alert.informativeText = "SCSI-U を切断して SASI に切り替えます。よろしいですか？"
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Switch")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() != .alertFirstButtonReturn { return }
+            coreDisconnectSCSIU()
+        }
+
+        if currentMode == .scsi && coreGetSCSI0State().ready {
             let alert = NSAlert()
             alert.messageText = "Switch to SASI Mode?"
             alert.informativeText = "SCSI (ID 0) をアンマウントして SASI に切り替えます。よろしいですか？"
@@ -2148,11 +2256,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
             alert.addButton(withTitle: "Switch")
             alert.addButton(withTitle: "Cancel")
             if alert.runModal() != .alertFirstButtonReturn { return }
-            // Eject SCSI state via core
             if coreEjectSCSI0() {
-                let defaults = UserDefaults.standard
-                defaults.scsi0Ready = false
-                defaults.scsi0Filename = nil
+                clearPersistedSCSI0State()
                 DiskStateManager.shared.recordHDDEject()
             }
         }
@@ -2169,9 +2274,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
 
     @objc func setStorageBusSCSI(_ sender: Any?) {
         guard coreGetStorageBusMode() != .scsi else { return }
+        let currentMode = coreGetStorageBusMode()
 
-        // If SASI HDD is mounted, confirm unmount
-        if getCachedHDDReady() {
+        if currentMode == .scsiU && coreGetSCSIUState().connected {
+            let alert = NSAlert()
+            alert.messageText = "Switch to SCSI Mode?"
+            alert.informativeText = "SCSI-U を切断して SCSI イメージに切り替えます。よろしいですか？"
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Switch")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() != .alertFirstButtonReturn { return }
+            coreDisconnectSCSIU()
+        }
+
+        if currentMode == .sasi && getCachedHDDReady() {
             let alert = NSAlert()
             alert.messageText = "Switch to SCSI Mode?"
             alert.informativeText = "SASI のハードディスクをアンマウントして SCSI に切り替えます。よろしいですか？"
@@ -2179,13 +2295,74 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
             alert.addButton(withTitle: "Switch")
             alert.addButton(withTitle: "Cancel")
             if alert.runModal() != .alertFirstButtonReturn { return }
-            // Eject SASI HDD via existing action
             gameViewController?.ejectHDD(self)
         }
 
         coreSetStorageBusMode(.scsi)
         UserDefaults.standard.storageBusMode = .scsi
         cachedStorageBusMode = StorageBusMode.scsi.rawValue
+        updateMenuTitles()
+    }
+
+    @objc func setStorageBusSCSIU(_ sender: Any?) {
+        guard coreGetStorageBusMode() != .scsiU else { return }
+
+        if coreGetSCSI0State().ready {
+            let alert = NSAlert()
+            alert.messageText = "Switch to SCSI-U Mode?"
+            alert.informativeText = "SCSI イメージをアンマウントして SCSI-U に切り替えます。よろしいですか？"
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Switch")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() != .alertFirstButtonReturn { return }
+            if coreEjectSCSI0() {
+                clearPersistedSCSI0State()
+                DiskStateManager.shared.recordHDDEject()
+            }
+        } else if getCachedHDDReady() {
+            let alert = NSAlert()
+            alert.messageText = "Switch to SCSI-U Mode?"
+            alert.informativeText = "SASI のハードディスクをアンマウントして SCSI-U に切り替えます。よろしいですか？"
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Switch")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() != .alertFirstButtonReturn { return }
+            gameViewController?.ejectHDD(self)
+        }
+
+        coreSetStorageBusMode(.scsiU)
+        if !coreConnectSCSIU() {
+            coreSetStorageBusMode(.sasi)
+            cachedStorageBusMode = StorageBusMode.sasi.rawValue
+            UserDefaults.standard.storageBusMode = .sasi
+            showSCSIUConnectionFailureAlert()
+            updateMenuTitles()
+            return
+        }
+
+        clearPersistedSCSI0State()
+        UserDefaults.standard.storageBusMode = .scsiU
+        cachedStorageBusMode = StorageBusMode.scsiU.rawValue
+        updateMenuTitles()
+    }
+
+    @objc func connectSCSIU(_ sender: Any?) {
+        guard coreGetStorageBusMode() == .scsiU else { return }
+        guard !coreGetSCSIUState().connected else { return }
+
+        if !coreConnectSCSIU() {
+            showSCSIUConnectionFailureAlert()
+        }
+        updateMenuTitles()
+    }
+
+    @objc func disconnectSCSIU(_ sender: Any?) {
+        guard coreGetStorageBusMode() == .scsiU else { return }
+        guard coreGetSCSIUState().connected else { return }
+
+        coreDisconnectSCSIU()
+        UserDefaults.standard.storageBusMode = .sasi
+        cachedStorageBusMode = StorageBusMode.sasi.rawValue
         updateMenuTitles()
     }
 
@@ -2231,9 +2408,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
         guard coreGetStorageBusMode() == .scsi else { return }
         if coreGetSCSI0State().ready {
             if coreEjectSCSI0() {
-                let defaults = UserDefaults.standard
-                defaults.scsi0Ready = false
-                defaults.scsi0Filename = nil
+                clearPersistedSCSI0State()
                 infoLog("SCSI(ID0) image ejected", category: .fileSystem)
                 NotificationCenter.default.post(name: .diskImageLoaded, object: nil)
                 updateMenuOnFileOperation()
@@ -2879,6 +3054,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
                 menuItem.state = (busMode == .sasi) ? .on : .off
             case "HDD-bus-SCSI":
                 menuItem.state = (busMode == .scsi) ? .on : .off
+            case "HDD-bus-SCSIU":
+                menuItem.state = (busMode == .scsiU) ? .on : .off
             case "HDD-open", "HDD-create":
                 return busMode == .sasi
             case "HDD-eject", "HDD-save":
@@ -2887,6 +3064,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
                 return busMode == .scsi
             case "SCSI0-eject":
                 return busMode == .scsi && coreGetSCSI0State().ready
+            case "SCSIU-status":
+                return false
+            case "SCSIU-connect":
+                return busMode == .scsiU && !coreGetSCSIUState().connected
+            case "SCSIU-disconnect":
+                return busMode == .scsiU && coreGetSCSIUState().connected
             default:
                 break
             }
@@ -2909,6 +3092,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
             $0.identifier?.rawValue == "SCSI-devices"
         }) else { return }
         scsiDevicesItem.isEnabled = (coreGetStorageBusMode() == .scsi)
+        if let scsiUDevicesItem = menu.items.first(where: {
+            $0.identifier?.rawValue == "SCSIU-device"
+        }) {
+            scsiUDevicesItem.isEnabled = (coreGetStorageBusMode() == .scsiU)
+        }
     }
 
 }

--- a/X68000 macOS/AppDelegate.swift
+++ b/X68000 macOS/AppDelegate.swift
@@ -76,6 +76,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
     private let maxStorageRestoreRetries: Int = 5
     private let storageRestoreRetryDelay: TimeInterval = 0.6
     private var isPresentingSCSIOpenPanel = false
+    private var isConnectingSCSIU = false
 
     // MARK: - Core Bridge Helpers
     private func resetSCSILogs() {
@@ -417,6 +418,38 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
             alert.beginSheetModal(for: window, completionHandler: nil)
         } else {
             alert.runModal()
+        }
+    }
+
+    private func performSCSIUConnect(rollbackToSASIOnFailure: Bool,
+                                     onSuccess: (() -> Void)? = nil) {
+        guard !isConnectingSCSIU else { return }
+
+        isConnectingSCSIU = true
+        updateMenuTitles()
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+
+            let connected = self.coreConnectSCSIU()
+
+            DispatchQueue.main.async {
+                self.isConnectingSCSIU = false
+
+                if connected {
+                    onSuccess?()
+                } else {
+                    if rollbackToSASIOnFailure {
+                        self.coreSetStorageBusMode(.sasi)
+                        UserDefaults.standard.storageBusMode = .sasi
+                        self.cachedStorageBusMode = StorageBusMode.sasi.rawValue
+                        DiskStateManager.shared.saveCurrentState()
+                    }
+                    self.showSCSIUConnectionFailureAlert()
+                }
+
+                self.updateMenuTitles()
+            }
         }
     }
 
@@ -1848,6 +1881,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
 
         let busMode = coreGetStorageBusMode()
         let scsiU = coreGetSCSIUState()
+        let statusText = isConnectingSCSIU ? "Connecting..." : scsiU.status
 
         scsiUDevicesItem.isEnabled = (busMode == .scsiU)
 
@@ -1855,14 +1889,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
             let itemId = item.identifier?.rawValue ?? ""
             switch itemId {
             case "SCSIU-status":
-                item.title = "Status: \(scsiU.status)"
+                item.title = "Status: \(statusText)"
                 item.isEnabled = false
             case "SCSIU-connect":
-                item.title = scsiU.connected ? "Reconnect SCSI-U" : "Connect SCSI-U"
-                item.isEnabled = (busMode == .scsiU && !scsiU.connected)
+                item.title = isConnectingSCSIU ? "Connecting SCSI-U..." :
+                             (scsiU.connected ? "Reconnect SCSI-U" : "Connect SCSI-U")
+                item.isEnabled = (busMode == .scsiU && !isConnectingSCSIU)
             case "SCSIU-disconnect":
                 item.title = "Disconnect SCSI-U"
-                item.isEnabled = (busMode == .scsiU && scsiU.connected)
+                item.isEnabled = (busMode == .scsiU && scsiU.connected && !isConnectingSCSIU)
             default:
                 break
             }
@@ -2301,6 +2336,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
         coreSetStorageBusMode(.scsi)
         UserDefaults.standard.storageBusMode = .scsi
         cachedStorageBusMode = StorageBusMode.scsi.rawValue
+        DiskStateManager.shared.saveCurrentState()
         updateMenuTitles()
     }
 
@@ -2331,29 +2367,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
         }
 
         coreSetStorageBusMode(.scsiU)
-        if !coreConnectSCSIU() {
-            coreSetStorageBusMode(.sasi)
-            cachedStorageBusMode = StorageBusMode.sasi.rawValue
-            UserDefaults.standard.storageBusMode = .sasi
-            showSCSIUConnectionFailureAlert()
-            updateMenuTitles()
-            return
+        performSCSIUConnect(rollbackToSASIOnFailure: true) { [weak self] in
+            guard let self = self else { return }
+            self.clearPersistedSCSI0State()
+            UserDefaults.standard.storageBusMode = .scsiU
+            self.cachedStorageBusMode = StorageBusMode.scsiU.rawValue
+            DiskStateManager.shared.saveCurrentState()
         }
-
-        clearPersistedSCSI0State()
-        UserDefaults.standard.storageBusMode = .scsiU
-        cachedStorageBusMode = StorageBusMode.scsiU.rawValue
-        updateMenuTitles()
     }
 
     @objc func connectSCSIU(_ sender: Any?) {
         guard coreGetStorageBusMode() == .scsiU else { return }
-        guard !coreGetSCSIUState().connected else { return }
-
-        if !coreConnectSCSIU() {
-            showSCSIUConnectionFailureAlert()
+        if coreGetSCSIUState().connected {
+            coreDisconnectSCSIU()
         }
-        updateMenuTitles()
+        performSCSIUConnect(rollbackToSASIOnFailure: false)
     }
 
     @objc func disconnectSCSIU(_ sender: Any?) {
@@ -2361,8 +2389,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
         guard coreGetSCSIUState().connected else { return }
 
         coreDisconnectSCSIU()
-        UserDefaults.standard.storageBusMode = .scsiU
-        cachedStorageBusMode = StorageBusMode.scsiU.rawValue
         updateMenuTitles()
     }
 
@@ -3067,9 +3093,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
             case "SCSIU-status":
                 return false
             case "SCSIU-connect":
-                return busMode == .scsiU && !coreGetSCSIUState().connected
+                return busMode == .scsiU && !isConnectingSCSIU
             case "SCSIU-disconnect":
-                return busMode == .scsiU && coreGetSCSIUState().connected
+                return busMode == .scsiU && coreGetSCSIUState().connected && !isConnectingSCSIU
             default:
                 break
             }

--- a/X68000 macOS/AppDelegate.swift
+++ b/X68000 macOS/AppDelegate.swift
@@ -2361,8 +2361,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation, NSMenu
         guard coreGetSCSIUState().connected else { return }
 
         coreDisconnectSCSIU()
-        UserDefaults.standard.storageBusMode = .sasi
-        cachedStorageBusMode = StorageBusMode.sasi.rawValue
+        UserDefaults.standard.storageBusMode = .scsiU
+        cachedStorageBusMode = StorageBusMode.scsiU.rawValue
         updateMenuTitles()
     }
 


### PR DESCRIPTION
統合した新しいすかじーUくん対応PRです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SCSI‑U storage mode with UI to connect/disconnect and show status.
  * HDD menu adds Storage Bus Mode selector (SASI, SCSI, SCSI‑U) and a SCSI‑U Device submenu with status/actions.

* **Bug Fixes**
  * Post‑restore boot/reset logic updated to consider SCSI‑U connections and avoid unwanted resets.
  * IPL ROM loading now uses the selected storage bus mode and updates missing‑ROM messages to reference SCSI/SCSI‑U mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->