### PR TITLE
Address CodeRabbit review feedback from PR #21

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -210,10 +210,9 @@ graph TB
 ```mermaid
 graph TB
     subgraph "Input Sources"
-        Touch[Touch Input<br/>iOS]
         Keyboard[Keyboard Input<br/>macOS]
         Mouse[Mouse Input<br/>macOS]
-        GameController[Game Controller<br/>Both Platforms]
+        GameController[Game Controller]
     end
     
     subgraph "Swift Input Processing"
@@ -229,7 +228,6 @@ graph TB
         MouseEmu[Mouse Emulation]
     end
     
-    Touch --> JoyCard
     Keyboard --> JoyCard
     Mouse --> JoyCard
     GameController --> GameplayKit
@@ -242,7 +240,6 @@ graph TB
     X68KInput --> KeyboardEmu
     X68KInput --> MouseEmu
     
-    style Touch fill:#e1f5fe
     style Keyboard fill:#e8f5e8
     style Mouse fill:#e8f5e8
     style JoyCard fill:#fff3e0
@@ -268,7 +265,6 @@ graph TD
     
     subgraph "Output"
         C68KLib[libc68k.a]
-        iOSApp[iOS App Bundle]
         macOSApp[macOS App Bundle]
     end
     
@@ -281,7 +277,6 @@ graph TD
     C68KLib --> MainBuild
     BridgingHeaders --> MainBuild
     
-    MainBuild --> iOSApp
     MainBuild --> macOSApp
     
     style C68KBuild fill:#f3e5f5
@@ -293,7 +288,7 @@ graph TD
 
 ### 1. Multi-Platform Strategy
 - **Shared Core**: Common business logic and emulation engine
-- **Platform-Specific UI**: Separate iOS and macOS presentation layers
+- **Platform UI**: macOS presentation layer kept separate from the shared core
 - **Conditional Compilation**: Platform-specific code using `#if os()` directives
 
 ### 2. Document-Based Architecture
@@ -343,4 +338,4 @@ The server runs on a dedicated POSIX thread and is lifecycle-managed by `AppDele
 
 `SO_NOSIGPIPE` is set on each accepted client fd so that a disconnecting client cannot deliver `SIGPIPE` to the main emulator process.  Memory writes are guarded: the protocol requires `PAUSE` before any `WRITE*` command to prevent mid-frame data races.
 
-This architecture enables MPX68K to provide authentic X68000 emulation while maintaining modern iOS and macOS user experience standards.
+This architecture enables MPX68K to provide authentic X68000 emulation while maintaining modern macOS user experience standards.

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -23,6 +23,14 @@ provenance of the third-party code vendored in this repository.
   Sega Saturn emulator through which this copy of C68K was distributed.
   Full license text: `LICENSES/GPL-2.0.txt`.
 
+## Debabelizer — M680x0 disassembler (d68k)
+
+- **Location**: `X68000 Shared/px68k/x68k/d68k.c`, `d68k.h`
+- **Author**: Copyright 1999 Karl Stenerud
+- **License**: Freeware. The license header states the code "may be freely
+  used as long as this copyright notice remains unaltered in the source code
+  and any binary files containing this code in compiled form."
+
 ## fmgen — FM Sound Generator
 
 - **Location**: `X68000 Shared/px68k/fmgen/`

--- a/LICENSE
+++ b/LICENSE
@@ -10,7 +10,9 @@ terms. See ATTRIBUTION.md for the full provenance of each component.
 |-----------|----------|-----------|---------|
 | C68K (M68000 CPU core) | `X68000 Shared/px68k/m68000/c68k/` | Stephane Dallongeville (as distributed with Yabause) | GPL-2.0-or-later (see `LICENSES/GPL-2.0.txt`) |
 | px68k emulator core | `X68000 Shared/px68k/` | hissorii, based on WinX68k by Kenjo (けろぴー) | Terms of the upstream px68k / WinX68k projects |
-| fmgen (FM sound generator) | `X68000 Shared/px68k/fmgen/` | cisc (1998–2003) | cisc's distribution terms (see source file headers) |
+| Debabelizer (d68k disassembler) | `X68000 Shared/px68k/x68k/d68k.c`, `d68k.h` | Karl Stenerud (1999) | Freeware; the copyright notice must remain unaltered in source and binaries (see `d68k.h` header) |
+| fmgen (FM sound generator) | `X68000 Shared/px68k/fmgen/` | cisc (1998–2003) | cisc's distribution terms (copyright notices in source file headers) |
+| win32api compatibility layer | `X68000 Shared/px68k/win32api/` | NONAKA Kimihiro (2003) | BSD-style license with advertising clause (see `win32api/dosio.h`) |
 | MPX68K Swift application layer and modifications | `X68000 Shared/`, `X68000 macOS/` | GOROman, YosAwed, and contributors | Distributed under the terms compatible with the components above |
 
 ## Note on the combined work

--- a/X68000 Shared/px68k/x68k/disk_d88.c
+++ b/X68000 Shared/px68k/x68k/disk_d88.c
@@ -66,61 +66,6 @@ int D88_SetFD(int drv, char* filename)
 	strncpy(D88File[drv], filename, MAX_PATH);
 	D88File[drv][MAX_PATH-1] = 0;
 
-#ifdef TARGET_IOS
-	extern BYTE* s_disk_image_buffer[5];
-	BYTE* Game = s_disk_image_buffer[drv];
-	unsigned char* Ptr = Game;
-	
-//	if ( File_Read(fp, &D88Head[drv], sizeof(D88_HEADER))!=sizeof(D88_HEADER) ) goto d88_set_error;
-	memcpy( &D88Head[drv], Ptr, sizeof(D88_HEADER) );	Ptr += sizeof(D88_HEADER);
-	
-	if ( D88Head[drv].protect ) {
-		FDD_SetReadOnly(drv);
-	}
-
-	for (trk=0; trk<164; trk++) {
-		long ptr = D88Head[drv].trackp[trk];
-		D88_SECTINFO *si, *oldsi = NULL;
-		
-		if ( (ptr>=(long)sizeof(D88_HEADER))&&(ptr<D88Head[drv].fd_size) ) {
-			d88s.sectors = 65535;
-//			File_Seek(fp, ptr, FSEEK_SET);
-			Ptr = Game + ptr;
-			
-			for (sct=0; sct<d88s.sectors; sct++) {
-//				if ( File_Read(fp, &d88s, sizeof(D88_SECTOR))!=sizeof(D88_SECTOR) ) goto d88_set_error;
-				memcpy( &d88s, Ptr, sizeof(D88_SECTOR));	Ptr += sizeof(D88_SECTOR);
-
-				// Security: Validate sector count from image header
-				if (d88s.sectors == 0 || d88s.sectors > MAX_SECTORS_PER_TRACK) {
-					goto d88_set_error;
-				}
-				// Security: Validate sector size to prevent buffer overflow
-				if (d88s.size > MAX_SECTOR_SIZE) {
-					goto d88_set_error;
-				}
-				// Security: Check for integer overflow in allocation
-				size_t alloc_size = sizeof(D88_SECTINFO) + d88s.size;
-				if (alloc_size > MAX_ALLOCATION_SIZE || alloc_size < sizeof(D88_SECTINFO)) {
-					goto d88_set_error;
-				}
-				si = (D88_SECTINFO*)malloc(alloc_size);
-				if ( !si ) goto d88_set_error;
-				if ( sct ) {
-					oldsi->next = si;
-				} else {
-					D88Trks[drv][trk] = si;
-				}
-				memcpy(&si->sect, &d88s, sizeof(D88_SECTOR));
-
-				//				if ( File_Read(fp, ((unsigned char*)si)+sizeof(D88_SECTINFO), d88s.size)!=d88s.size ) goto d88_set_error;
-				memcpy( ((unsigned char*)si)+sizeof(D88_SECTINFO), Ptr, d88s.size);  Ptr += d88s.size;
-				si->next = 0;
-				oldsi = si;
-			}
-		}
-	}
-#else
 	fp = File_Open(D88File[drv]);
 	if ( !fp ) {
 		ZeroMemory(D88File[drv], MAX_PATH);
@@ -169,7 +114,6 @@ int D88_SetFD(int drv, char* filename)
 			}
 		}
 	}
-#endif
 	File_Close(fp);
 	return TRUE;
 

--- a/tests/core/stubs.c
+++ b/tests/core/stubs.c
@@ -13,49 +13,49 @@ static int s_read_only[4];
 
 void FDD_SetReadOnly(int drv)
 {
-	if (drv >= 0 && drv < 4)
-		s_read_only[drv] = 1;
+    if (drv >= 0 && drv < 4)
+        s_read_only[drv] = 1;
 }
 
 int FDD_IsReadOnly(int drv)
 {
-	if (drv >= 0 && drv < 4)
-		return s_read_only[drv];
-	return 0;
+    if (drv >= 0 && drv < 4)
+        return s_read_only[drv];
+    return 0;
 }
 
 void stub_reset_read_only(void)
 {
-	memset(s_read_only, 0, sizeof(s_read_only));
+    memset(s_read_only, 0, sizeof(s_read_only));
 }
 
 /* ---- dosio.h (file_* used via the File_* macros in fileio.h) ---- */
 FILEH file_open(LPSTR filename)
 {
-	return (FILEH)fopen((const char *)filename, "r+b");
+    return (FILEH)fopen((const char *)filename, "r+b");
 }
 
 DWORD file_seek(FILEH handle, long pointer, short mode)
 {
-	int whence = (mode == FSEEK_SET) ? SEEK_SET
-	           : (mode == FSEEK_CUR) ? SEEK_CUR
-	           : SEEK_END;
-	if (fseek((FILE *)handle, pointer, whence) != 0)
-		return (DWORD)-1;
-	return (DWORD)ftell((FILE *)handle);
+    int whence = (mode == FSEEK_SET) ? SEEK_SET
+               : (mode == FSEEK_CUR) ? SEEK_CUR
+               : SEEK_END;
+    if (fseek((FILE *)handle, pointer, whence) != 0)
+        return (DWORD)-1;
+    return (DWORD)ftell((FILE *)handle);
 }
 
 DWORD file_lread(FILEH handle, void *data, DWORD length)
 {
-	return (DWORD)fread(data, 1, length, (FILE *)handle);
+    return (DWORD)fread(data, 1, length, (FILE *)handle);
 }
 
 DWORD file_lwrite(FILEH handle, void *data, DWORD length)
 {
-	return (DWORD)fwrite(data, 1, length, (FILE *)handle);
+    return (DWORD)fwrite(data, 1, length, (FILE *)handle);
 }
 
 short file_close(FILEH handle)
 {
-	return (short)fclose((FILE *)handle);
+    return (short)fclose((FILE *)handle);
 }

--- a/tests/core/test_disk_d88.c
+++ b/tests/core/test_disk_d88.c
@@ -23,12 +23,12 @@ extern void stub_reset_read_only(void);
 static int g_failures = 0;
 
 #define CHECK(cond, name) do { \
-	if (cond) { \
-		printf("PASS: %s\n", name); \
-	} else { \
-		printf("FAIL: %s (%s:%d)\n", name, __FILE__, __LINE__); \
-		g_failures++; \
-	} \
+    if (cond) { \
+        printf("PASS: %s\n", name); \
+    } else { \
+        printf("FAIL: %s (%s:%d)\n", name, __FILE__, __LINE__); \
+        g_failures++; \
+    } \
 } while (0)
 
 /* Serialize a D88 header + one track with `sectors` sector entries of
@@ -37,113 +37,113 @@ static int g_failures = 0;
 static void write_image(const char *path, WORD sectors, WORD sector_size,
                         DWORD track0_ptr)
 {
-	BYTE header[D88_HEADER_SIZE];
-	FILE *fp = fopen(path, "wb");
-	DWORD fd_size;
-	WORD s;
+    BYTE header[D88_HEADER_SIZE];
+    FILE *fp = fopen(path, "wb");
+    DWORD fd_size;
+    WORD s;
 
-	if (!fp) {
-		perror("fopen");
-		exit(1);
-	}
+    if (!fp) {
+        perror("fopen");
+        exit(1);
+    }
 
-	fd_size = D88_HEADER_SIZE +
-	          (DWORD)sectors * (D88_SECTOR_HDR_SIZE + sector_size);
+    fd_size = D88_HEADER_SIZE +
+              (DWORD)sectors * (D88_SECTOR_HDR_SIZE + sector_size);
 
-	memset(header, 0, sizeof(header));
-	memcpy(header, "TESTDISK", 8);            /* fd_name */
-	/* offset 26: protect, 27: fd_type, 28: fd_size, 32: trackp[164] */
-	memcpy(header + 28, &fd_size, 4);
-	memcpy(header + 32, &track0_ptr, 4);      /* trackp[0] */
-	fwrite(header, 1, sizeof(header), fp);
+    memset(header, 0, sizeof(header));
+    memcpy(header, "TESTDISK", 8);            /* fd_name */
+    /* offset 26: protect, 27: fd_type, 28: fd_size, 32: trackp[164] */
+    memcpy(header + 28, &fd_size, 4);
+    memcpy(header + 32, &track0_ptr, 4);      /* trackp[0] */
+    fwrite(header, 1, sizeof(header), fp);
 
-	for (s = 0; s < sectors; s++) {
-		BYTE sect_hdr[D88_SECTOR_HDR_SIZE];
-		BYTE *data = calloc(1, sector_size);
+    for (s = 0; s < sectors; s++) {
+        BYTE sect_hdr[D88_SECTOR_HDR_SIZE];
+        BYTE *data = calloc(1, sector_size);
 
-		memset(sect_hdr, 0, sizeof(sect_hdr));
-		sect_hdr[0] = 0;                  /* c */
-		sect_hdr[1] = 0;                  /* h */
-		sect_hdr[2] = (BYTE)(s + 1);      /* r */
-		sect_hdr[3] = 1;                  /* n (256 bytes) */
-		memcpy(sect_hdr + 4, &sectors, 2);     /* sectors per track */
-		memcpy(sect_hdr + 14, &sector_size, 2);/* sector size */
-		fwrite(sect_hdr, 1, sizeof(sect_hdr), fp);
-		fwrite(data, 1, sector_size, fp);
-		free(data);
-	}
-	fclose(fp);
+        memset(sect_hdr, 0, sizeof(sect_hdr));
+        sect_hdr[0] = 0;                  /* c */
+        sect_hdr[1] = 0;                  /* h */
+        sect_hdr[2] = (BYTE)(s + 1);      /* r */
+        sect_hdr[3] = 1;                  /* n (256 bytes) */
+        memcpy(sect_hdr + 4, &sectors, 2);     /* sectors per track */
+        memcpy(sect_hdr + 14, &sector_size, 2);/* sector size */
+        fwrite(sect_hdr, 1, sizeof(sect_hdr), fp);
+        fwrite(data, 1, sector_size, fp);
+        free(data);
+    }
+    fclose(fp);
 }
 
 static int load_image(const char *path)
 {
-	int result;
+    int result;
 
-	stub_reset_read_only();
-	D88_Init();
-	result = D88_SetFD(0, (char *)path);
-	D88_Eject(0);
-	return result;
+    stub_reset_read_only();
+    D88_Init();
+    result = D88_SetFD(0, (char *)path);
+    D88_Eject(0);
+    return result;
 }
 
 int main(void)
 {
-	const char *path = "_test_image.d88";
+    const char *path = "_test_image.d88";
 
-	/* 1. Well-formed image: 8 sectors x 256 bytes on track 0 */
-	write_image(path, 8, 256, D88_HEADER_SIZE);
-	CHECK(load_image(path) == TRUE, "valid image accepted");
+    /* 1. Well-formed image: 8 sectors x 256 bytes on track 0 */
+    write_image(path, 8, 256, D88_HEADER_SIZE);
+    CHECK(load_image(path) == TRUE, "valid image accepted");
 
-	/* 2. Sector size beyond MAX_SECTOR_SIZE (8192) must be rejected */
-	write_image(path, 1, 16384, D88_HEADER_SIZE);
-	CHECK(load_image(path) == FALSE, "oversized sector rejected");
+    /* 2. Sector size beyond MAX_SECTOR_SIZE (8192) must be rejected */
+    write_image(path, 1, 16384, D88_HEADER_SIZE);
+    CHECK(load_image(path) == FALSE, "oversized sector rejected");
 
-	/* 3. Sector count of zero must be rejected */
-	write_image(path, 0, 256, D88_HEADER_SIZE);
-	/* with sectors=0 no sector data is emitted, so craft one header
-	 * manually claiming 0 sectors */
-	{
-		FILE *fp = fopen(path, "r+b");
-		BYTE sect_hdr[D88_SECTOR_HDR_SIZE];
-		WORD zero = 0, size = 256;
-		DWORD fd_size = D88_HEADER_SIZE + D88_SECTOR_HDR_SIZE + 256;
-		memset(sect_hdr, 0, sizeof(sect_hdr));
-		memcpy(sect_hdr + 4, &zero, 2);
-		memcpy(sect_hdr + 14, &size, 2);
-		fseek(fp, 28, SEEK_SET);
-		fwrite(&fd_size, 1, 4, fp);
-		fseek(fp, D88_HEADER_SIZE, SEEK_SET);
-		fwrite(sect_hdr, 1, sizeof(sect_hdr), fp);
-		fclose(fp);
-	}
-	CHECK(load_image(path) == FALSE, "zero sector count rejected");
+    /* 3. Sector count of zero must be rejected */
+    write_image(path, 0, 256, D88_HEADER_SIZE);
+    /* with sectors=0 no sector data is emitted, so craft one header
+     * manually claiming 0 sectors */
+    {
+        FILE *fp = fopen(path, "r+b");
+        BYTE sect_hdr[D88_SECTOR_HDR_SIZE];
+        WORD zero = 0, size = 256;
+        DWORD fd_size = D88_HEADER_SIZE + D88_SECTOR_HDR_SIZE + 256;
+        memset(sect_hdr, 0, sizeof(sect_hdr));
+        memcpy(sect_hdr + 4, &zero, 2);
+        memcpy(sect_hdr + 14, &size, 2);
+        fseek(fp, 28, SEEK_SET);
+        fwrite(&fd_size, 1, 4, fp);
+        fseek(fp, D88_HEADER_SIZE, SEEK_SET);
+        fwrite(sect_hdr, 1, sizeof(sect_hdr), fp);
+        fclose(fp);
+    }
+    CHECK(load_image(path) == FALSE, "zero sector count rejected");
 
-	/* 4. Sector count above MAX_SECTORS_PER_TRACK (64) must be rejected */
-	write_image(path, 100, 256, D88_HEADER_SIZE);
-	CHECK(load_image(path) == FALSE, "excessive sector count rejected");
+    /* 4. Sector count above MAX_SECTORS_PER_TRACK (64) must be rejected */
+    write_image(path, 100, 256, D88_HEADER_SIZE);
+    CHECK(load_image(path) == FALSE, "excessive sector count rejected");
 
-	/* 5. Track pointer outside the image: track is skipped, disk loads */
-	write_image(path, 8, 256, 0x7FFFFFFF);
-	CHECK(load_image(path) == TRUE, "out-of-range track pointer skipped");
+    /* 5. Track pointer outside the image: track is skipped, disk loads */
+    write_image(path, 8, 256, 0x7FFFFFFF);
+    CHECK(load_image(path) == TRUE, "out-of-range track pointer skipped");
 
-	/* 6. Truncated image: header promises sectors the file doesn't have */
-	write_image(path, 8, 256, D88_HEADER_SIZE);
-	{
-		FILE *fp = fopen(path, "r+b");
-		DWORD fd_size = D88_HEADER_SIZE + 8 * (D88_SECTOR_HDR_SIZE + 256);
-		fseek(fp, 28, SEEK_SET);
-		fwrite(&fd_size, 1, 4, fp);
-		fclose(fp);
-		truncate(path, D88_HEADER_SIZE + 2 * (D88_SECTOR_HDR_SIZE + 256));
-	}
-	CHECK(load_image(path) == FALSE, "truncated image rejected");
+    /* 6. Truncated image: header promises sectors the file doesn't have */
+    write_image(path, 8, 256, D88_HEADER_SIZE);
+    {
+        FILE *fp = fopen(path, "r+b");
+        DWORD fd_size = D88_HEADER_SIZE + 8 * (D88_SECTOR_HDR_SIZE + 256);
+        fseek(fp, 28, SEEK_SET);
+        fwrite(&fd_size, 1, 4, fp);
+        fclose(fp);
+        truncate(path, D88_HEADER_SIZE + 2 * (D88_SECTOR_HDR_SIZE + 256));
+    }
+    CHECK(load_image(path) == FALSE, "truncated image rejected");
 
-	remove(path);
+    remove(path);
 
-	if (g_failures) {
-		printf("\n%d test(s) FAILED\n", g_failures);
-		return 1;
-	}
-	printf("\nAll tests passed\n");
-	return 0;
+    if (g_failures) {
+        printf("\n%d test(s) FAILED\n", g_failures);
+        return 1;
+    }
+    printf("\nAll tests passed\n");
+    return 0;
 }


### PR DESCRIPTION
## Change Description

Follow-up to #21 addressing the CodeRabbit review findings (verified against the codebase before applying):

- **disk_d88.c**: remove the `TARGET_IOS` parsing branch as dead code (no build defines `TARGET_IOS`; the branch also lacked the bounds checks the live path has)
- **tests/core**: tabs → 4-space indentation per AGENTS.md C guidelines (Makefile recipe tabs kept — required by make)
- **ARCHITECTURE.md**: remove leftover iOS artifacts (Touch input node, iOS App Bundle in build diagram, closing "iOS and macOS" sentence)
- **LICENSE / ATTRIBUTION.md**: add Debabelizer d68k disassembler (Karl Stenerud, freeware) and the win32api layer (NONAKA Kimihiro, BSD-style) to the component license table

Not addressed (with reason): Cppcheck null-deref warnings in the test harness — host-side test code where allocation failure aborts the test run, which is the desired behavior.

## Testing Method
- `make -C tests/core` — 6/6 pass
- `gcc -fsyntax-only` on disk_d88.c
- macOS CI job in this PR verifies the app build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Architecture documentation updated to reflect macOS-exclusive platform design strategy
  * Added comprehensive attributions and licensing information for third-party components

* **Chores**
  * Removed deprecated iOS platform support and associated implementation code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->